### PR TITLE
Add Mysql Protocol, only support text protocol now, not support trans…

### DIFF
--- a/docs/cn/mysql_client.md
+++ b/docs/cn/mysql_client.md
@@ -1,0 +1,93 @@
+```
+[mysql](https://www.mysql.com/)是著名的开源的关系型数据库，为了使用户更快捷地访问mysql并充分利用bthread的并发能力，brpc直接支持mysql协议。示例程序：[example/mysql_c++](https://github.com/brpc/brpc/tree/master/example/mysql_c++/)
+
+**注意**：brpc只支持MySQL 4.1 及之后的版本的文本协议。目前还不支持事务、Prepare statement，未来将会支持。目前支持的鉴权方式为mysql_native_password
+
+相比使用[libmysqlclient](https://dev.mysql.com/downloads/connector/c/)(官方client)的优势有：
+
+- 线程安全。用户不需要为每个线程建立独立的client。
+- 支持同步、异步、半同步等访问方式，能使用[ParallelChannel等](combo_channel.md)组合访问方式。
+- 支持多种[连接方式](client.md#连接方式)。支持超时、backup request、取消、tracing、内置服务等一系列brpc提供的福利。
+- 明确的返回类型校验，如果使用了不正确的变量接受mysql的数据类型，将抛出异常。
+
+# 访问mysql
+
+创建一个访问mysql的Channel：
+
+​```c++
+#include <brpc/mysql.h>
+#include <brpc/policy/mysql_authenticator.h>
+#include <brpc/channel.h>
+ 
+brpc::ChannelOptions options;
+options.protocol = brpc::PROTOCOL_MYSQL;
+options.connection_type = FLAGS_connection_type;
+options.timeout_ms = FLAGS_timeout_ms /*milliseconds*/;
+options.max_retry = FLAGS_max_retry;
+options.auth = new brpc::policy::MysqlAuthenticator("yangliming01", "123456", "test");
+if (channel.Init("127.0.0.1", 3306, &options) != 0) {
+    LOG(ERROR) << "Fail to initialize channel";
+    return -1;
+}
+... 
+​```
+
+向mysql发起命令。
+
+​```c++
+// 执行各种mysql命令，可以批量执行命令如："select * from tab1;select * from tab2"
+std::string command = "show databases"; // select,delete,update,insert,create,drop ...
+brpc::MysqlRequest request;
+if (!request.Query(command)) {
+    LOG(ERROR) << "Fail to add command";
+    return false;
+}
+brpc::MysqlResponse response;
+brpc::Controller cntl;
+channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+if (!cntl.Failed()) {
+    std::cout << response << std::endl;
+} else {
+    LOG(ERROR) << "Fail to access mysql, " << cntl.ErrorText();
+    return false;
+}
+return true;
+...
+​```
+
+上述代码的说明：
+
+- 请求类型必须为MysqlRequest，回复类型必须为MysqlResponse，否则CallMethod会失败。不需要stub，直接调用channel.CallMethod，method填NULL。
+- 调用request.Query()传入要执行的命令，可以批量执行命令，多个命令用分号隔开。
+- 依次调用response.reply(X)弹出操作结果，根据返回类型的不同，选择不同的类型接收，如：MysqlReply::Ok，MysqlReply::Error，const MysqlReply::Columnconst MysqlReply::Row等。
+- 如果只有一条命令则reply为1个，如果为批量操作返回的reply为多个。
+
+目前支持的请求操作有：
+
+​```c++
+bool Query(const std::string& stmt);
+​```
+
+对应的回复操作：
+
+​```c++
+// 返回不同类型的结果
+const MysqlReply::Auth* auth() const;
+const MysqlReply::Ok* ok() const;
+const MysqlReply::Error* error() const;
+const MysqlReply::Eof* eof() const;
+// 对result set结果集的操作
+// get column number
+uint64_t MysqlReply::column_number() const;
+// get one column
+const MysqlReply::Column* MysqlReply::column(const uint64_t index) const;
+// get row number
+uint64_t MysqlReply::row_number() const;
+// get one row
+const MysqlReply::Row* MysqlReply::next() const;
+// 结果集中每个字段的操作
+const MysqlReply::Field& MysqlReply::Row::field(const uint64_t index) const
+​```
+
+```
+

--- a/example/mysql_c++/CMakeLists.txt
+++ b/example/mysql_c++/CMakeLists.txt
@@ -1,0 +1,132 @@
+cmake_minimum_required(VERSION 2.8.10)
+project(mysql_c++ C CXX)
+
+# Install dependencies:
+# With apt:
+# sudo apt-get install libreadline-dev 
+# sudo apt-get install ncurses-dev
+# With yum:
+# sudo yum install readline-devel
+# sudo yum install ncurses-devel
+
+option(EXAMPLE_LINK_SO "Whether examples are linked dynamically" OFF)
+
+execute_process(
+    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
+    OUTPUT_VARIABLE OUTPUT_PATH
+)
+
+set(CMAKE_PREFIX_PATH ${OUTPUT_PATH})
+
+include(FindThreads)
+include(FindProtobuf)
+
+# Search for libthrift* by best effort. If it is not found and brpc is
+# compiled with thrift protocol enabled, a link error would be reported.
+find_library(THRIFT_LIB NAMES thrift)
+if (NOT THRIFT_LIB)
+    set(THRIFT_LIB "")
+endif()
+find_library(THRIFTNB_LIB NAMES thriftnb)
+if (NOT THRIFTNB_LIB)
+    set(THRIFTNB_LIB "")
+endif()
+
+find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
+if(EXAMPLE_LINK_SO)
+    find_library(BRPC_LIB NAMES brpc)
+else()
+    find_library(BRPC_LIB NAMES libbrpc.a brpc)
+endif()
+if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
+    message(FATAL_ERROR "Fail to find brpc")
+endif()
+include_directories(${BRPC_INCLUDE_PATH})
+
+find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
+find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
+if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
+    message(FATAL_ERROR "Fail to find gflags")
+endif()
+include_directories(${GFLAGS_INCLUDE_PATH})
+
+execute_process(
+    COMMAND bash -c "grep \"namespace [_A-Za-z0-9]\\+ {\" ${GFLAGS_INCLUDE_PATH}/gflags/gflags_declare.h | head -1 | awk '{print $2}' | tr -d '\n'"
+    OUTPUT_VARIABLE GFLAGS_NS
+)
+if(${GFLAGS_NS} STREQUAL "GFLAGS_NAMESPACE")
+    execute_process(
+        COMMAND bash -c "grep \"#define GFLAGS_NAMESPACE [_A-Za-z0-9]\\+\" ${GFLAGS_INCLUDE_PATH}/gflags/gflags_declare.h | head -1 | awk '{print $3}' | tr -d '\n'"
+        OUTPUT_VARIABLE GFLAGS_NS
+    )
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    include(CheckFunctionExists)
+    CHECK_FUNCTION_EXISTS(clock_gettime HAVE_CLOCK_GETTIME)
+    if(NOT HAVE_CLOCK_GETTIME)
+        set(DEFINE_CLOCK_GETTIME "-DNO_CLOCK_GETTIME_IN_MAC")
+    endif()
+endif()
+
+set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+
+if(CMAKE_VERSION VERSION_LESS "3.1.3")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+else()
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
+find_library(LEVELDB_LIB NAMES leveldb)
+if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
+    message(FATAL_ERROR "Fail to find leveldb")
+endif()
+include_directories(${LEVELDB_INCLUDE_PATH})
+
+find_library(SSL_LIB NAMES ssl)
+if (NOT SSL_LIB)
+    message(FATAL_ERROR "Fail to find ssl")
+endif()
+
+find_library(CRYPTO_LIB NAMES crypto)
+if (NOT CRYPTO_LIB)
+    message(FATAL_ERROR "Fail to find crypto")
+endif()
+
+set(DYNAMIC_LIB
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${GFLAGS_LIBRARY}
+    ${PROTOBUF_LIBRARIES}
+    ${LEVELDB_LIB}
+    ${SSL_LIB}
+    ${CRYPTO_LIB}
+    ${THRIFT_LIB}
+    ${THRIFTNB_LIB}
+    dl
+    )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(DYNAMIC_LIB ${DYNAMIC_LIB}
+        pthread
+        "-framework CoreFoundation"
+        "-framework CoreGraphics"
+        "-framework CoreData"
+        "-framework CoreText"
+        "-framework Security"
+        "-framework Foundation"
+        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
+        "-Wl,-U,_ProfilerStart"
+        "-Wl,-U,_ProfilerStop")
+endif()
+
+add_executable(mysql_cli mysql_cli.cpp)
+
+set(AUX_LIB readline ncurses)
+target_link_libraries(mysql_cli ${BRPC_LIB} ${DYNAMIC_LIB} ${AUX_LIB})

--- a/example/mysql_c++/mysql_cli.cpp
+++ b/example/mysql_c++/mysql_cli.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2014 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A brpc based command-line interface to talk with mysql-server
+
+#include <signal.h>
+#include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include <gflags/gflags.h>
+#include <butil/logging.h>
+#include <brpc/channel.h>
+#include <brpc/mysql.h>
+#include <brpc/policy/mysql_authenticator.h>
+
+DEFINE_string(connection_type,
+              "pooled",
+              "Connection type. Available values: single, pooled, short");
+DEFINE_string(server, "127.0.0.1", "IP Address of server");
+DEFINE_int32(timeout_ms, 5000, "RPC timeout in milliseconds");
+DEFINE_int32(max_retry, 3, "Max retries(not including the first RPC)");
+
+namespace brpc {
+const char* logo();
+}
+
+// Send `command' to mysql-server via `channel'
+static bool access_mysql(brpc::Channel& channel, const char* command) {
+    brpc::MysqlRequest request;
+    LOG(INFO) << "command=" << command;
+    if (!request.Query(command)) {
+        LOG(ERROR) << "Fail to add command";
+        return false;
+    }
+    brpc::MysqlResponse response;
+    brpc::Controller cntl;
+    channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+    if (!cntl.Failed()) {
+        std::cout << response << std::endl;
+    } else {
+        LOG(ERROR) << "Fail to access mysql, " << cntl.ErrorText();
+        return false;
+    }
+    return true;
+}
+
+// For freeing the memory returned by readline().
+struct Freer {
+    void operator()(char* mem) {
+        free(mem);
+    }
+};
+
+static void dummy_handler(int) {}
+
+// The getc for readline. The default getc retries reading when meeting
+// EINTR, which is not what we want.
+static bool g_canceled = false;
+static int cli_getc(FILE* stream) {
+    int c = getc(stream);
+    if (c == EOF && errno == EINTR) {
+        g_canceled = true;
+        return '\n';
+    }
+    return c;
+}
+
+int main(int argc, char* argv[]) {
+    // Parse gflags. We recommend you to use gflags as well.
+    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+
+    // A Channel represents a communication line to a Server. Notice that
+    // Channel is thread-safe and can be shared by all threads in your program.
+    brpc::Channel channel;
+
+    // Initialize the channel, NULL means using default options.
+    brpc::ChannelOptions options;
+    options.protocol = brpc::PROTOCOL_MYSQL;
+    options.connection_type = FLAGS_connection_type;
+    options.timeout_ms = FLAGS_timeout_ms /*milliseconds*/;
+    options.max_retry = FLAGS_max_retry;
+    options.auth = new brpc::policy::MysqlAuthenticator("yangliming01", "123456", "test");
+    if (channel.Init("127.0.0.1", 3306, &options) != 0) {
+        LOG(ERROR) << "Fail to initialize channel";
+        return -1;
+    }
+
+    if (argc <= 1) {  // interactive mode
+        // We need this dummy signal hander to interrupt getc (and returning
+        // EINTR), SIG_IGN did not work.
+        signal(SIGINT, dummy_handler);
+
+        // Hook getc of readline.
+        rl_getc_function = cli_getc;
+
+        // Print welcome information.
+        printf("%s\n", brpc::logo());
+        printf(
+            "This command-line tool mimics the look-n-feel of official "
+            "mysql-cli, as a demostration of brpc's capability of"
+            " talking to mysql-server. The output and behavior is "
+            "not exactly same with the official one.\n\n");
+
+        for (;;) {
+            char prompt[128];
+            snprintf(prompt, sizeof(prompt), "mysql %s> ", FLAGS_server.c_str());
+            std::unique_ptr<char, Freer> command(readline(prompt));
+            if (command == NULL || *command == '\0') {
+                if (g_canceled) {
+                    // No input after the prompt and user pressed Ctrl-C,
+                    // quit the CLI.
+                    return 0;
+                }
+                // User entered an empty command by just pressing Enter.
+                continue;
+            }
+            if (g_canceled) {
+                // User entered sth. and pressed Ctrl-C, start a new prompt.
+                g_canceled = false;
+                continue;
+            }
+            // Add user's command to history so that it's browse-able by
+            // UP-key and search-able by Ctrl-R.
+            add_history(command.get());
+
+            if (!strcmp(command.get(), "help")) {
+                printf("This is a mysql CLI written in brpc.\n");
+                continue;
+            }
+            if (!strcmp(command.get(), "quit")) {
+                // Although quit is a valid mysql command, it does not make
+                // too much sense to run it in this CLI, just quit.
+                return 0;
+            }
+            access_mysql(channel, command.get());
+        }
+    } else {
+        std::string command;
+        command.reserve(argc * 16);
+        for (int i = 1; i < argc; ++i) {
+            if (i != 1) {
+                command.push_back(' ');
+            }
+            command.append(argv[i]);
+        }
+        if (!access_mysql(channel, command.c_str())) {
+            return -1;
+        }
+    }
+    return 0;
+}

--- a/src/brpc/global.cpp
+++ b/src/brpc/global.cpp
@@ -68,6 +68,7 @@
 #include "brpc/policy/nshead_mcpack_protocol.h"
 #include "brpc/policy/rtmp_protocol.h"
 #include "brpc/policy/esp_protocol.h"
+#include "brpc/policy/mysql_protocol.h"
 #ifdef ENABLE_THRIFT_FRAMED_PROTOCOL
 # include "brpc/policy/thrift_protocol.h"
 #endif
@@ -561,6 +562,20 @@ static void GlobalInitializeOrDieImpl() {
         NULL, NULL, NULL,
         CONNECTION_TYPE_POOLED_AND_SHORT, "esp"};
     if (RegisterProtocol(PROTOCOL_ESP, esp_protocol) != 0) {
+        exit(1);
+    }
+
+    Protocol mysql_protocol = {ParseMysqlMessage,
+                               SerializeMysqlRequest,
+                               PackMysqlRequest,
+                               NULL,
+                               ProcessMysqlResponse,
+                               NULL,
+                               NULL,
+                               GetMysqlMethodName,
+                               CONNECTION_TYPE_ALL,
+                               "mysql"};
+    if (RegisterProtocol(PROTOCOL_MYSQL, mysql_protocol) != 0) {
         exit(1);
     }
 

--- a/src/brpc/mysql.cpp
+++ b/src/brpc/mysql.cpp
@@ -1,0 +1,491 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Yang,Liming (yangliming01@baidu.com)
+
+#define INTERNAL_SUPPRESS_PROTOBUF_FIELD_DEPRECATION
+#include <algorithm>
+#include <gflags/gflags.h>
+#include <google/protobuf/stubs/once.h>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/wire_format_lite_inl.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/reflection_ops.h>
+#include <google/protobuf/wire_format.h>
+#include "butil/string_printf.h"
+#include "butil/macros.h"
+#include "brpc/controller.h"
+#include "brpc/mysql.h"
+#include "brpc/mysql_command.h"
+#include "brpc/mysql_reply.h"
+
+namespace brpc {
+
+DEFINE_int32(mysql_max_replies, 50, "maximum replies size in one MysqlResponse");
+DEFINE_bool(mysql_verbose_crlf2space, false, "[DEBUG] Show \\r\\n as a space");
+
+// Internal implementation detail -- do not call these.
+void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_impl();
+void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+void protobuf_AssignDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+void protobuf_ShutdownFile_baidu_2frpc_2fmysql_5fbase_2eproto();
+
+namespace {
+
+const ::google::protobuf::Descriptor* MysqlRequest_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* MysqlResponse_descriptor_ = NULL;
+
+}  // namespace
+
+void protobuf_AssignDesc_baidu_2frpc_2fmysql_5fbase_2eproto() {
+    protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    const ::google::protobuf::FileDescriptor* file =
+        ::google::protobuf::DescriptorPool::generated_pool()->FindFileByName(
+            "baidu/rpc/mysql_base.proto");
+    GOOGLE_CHECK(file != NULL);
+    MysqlRequest_descriptor_ = file->message_type(0);
+    MysqlResponse_descriptor_ = file->message_type(1);
+}
+
+namespace {
+
+GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_AssignDescriptors_once_);
+inline void protobuf_AssignDescriptorsOnce() {
+    ::google::protobuf::GoogleOnceInit(&protobuf_AssignDescriptors_once_,
+                                       &protobuf_AssignDesc_baidu_2frpc_2fmysql_5fbase_2eproto);
+}
+
+void protobuf_RegisterTypes(const ::std::string&) {
+    protobuf_AssignDescriptorsOnce();
+    ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+        MysqlRequest_descriptor_, &MysqlRequest::default_instance());
+    ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+        MysqlResponse_descriptor_, &MysqlResponse::default_instance());
+}
+
+}  // namespace
+
+void protobuf_ShutdownFile_baidu_2frpc_2fmysql_5fbase_2eproto() {
+    delete MysqlRequest::default_instance_;
+    delete MysqlResponse::default_instance_;
+}
+
+void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_impl() {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#if GOOGLE_PROTOBUF_VERSION >= 3002000
+    ::google::protobuf::internal::InitProtobufDefaults();
+#else
+    ::google::protobuf::protobuf_AddDesc_google_2fprotobuf_2fdescriptor_2eproto();
+#endif
+    ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
+        "\n\032baidu/rpc/mysql_base.proto\022\tbaidu.rpc\032"
+        " google/protobuf/descriptor.proto\"\016\n\014Mys"
+        "qlRequest\"\017\n\rMysqlResponseB\003\200\001\001",
+        111);
+    ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile("baidu/rpc/mysql_base.proto",
+                                                                      &protobuf_RegisterTypes);
+    MysqlRequest::default_instance_ = new MysqlRequest();
+    MysqlResponse::default_instance_ = new MysqlResponse();
+    MysqlRequest::default_instance_->InitAsDefaultInstance();
+    MysqlResponse::default_instance_->InitAsDefaultInstance();
+    ::google::protobuf::internal::OnShutdown(
+        &protobuf_ShutdownFile_baidu_2frpc_2fmysql_5fbase_2eproto);
+}
+
+GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_once);
+void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto() {
+    ::google::protobuf::GoogleOnceInit(&protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_once,
+                                       &protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_impl);
+}
+
+// Force AddDescriptors() to be called at static initialization time.
+struct StaticDescriptorInitializer_baidu_2frpc_2fmysql_5fbase_2eproto {
+    StaticDescriptorInitializer_baidu_2frpc_2fmysql_5fbase_2eproto() {
+        protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    }
+} static_descriptor_initializer_baidu_2frpc_2fmysql_5fbase_2eproto_;
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+#endif  // !_MSC_VER
+
+MysqlRequest::MysqlRequest() : ::google::protobuf::Message() {
+    SharedCtor();
+}
+
+void MysqlRequest::InitAsDefaultInstance() {}
+
+MysqlRequest::MysqlRequest(const MysqlRequest& from) : ::google::protobuf::Message() {
+    SharedCtor();
+    MergeFrom(from);
+}
+
+void MysqlRequest::SharedCtor() {
+    _has_error = false;
+    _cached_size_ = 0;
+}
+
+MysqlRequest::~MysqlRequest() {
+    SharedDtor();
+}
+
+void MysqlRequest::SharedDtor() {
+    if (this != default_instance_) {
+    }
+}
+
+void MysqlRequest::SetCachedSize(int size) const {
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _cached_size_ = size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* MysqlRequest::descriptor() {
+    protobuf_AssignDescriptorsOnce();
+    return MysqlRequest_descriptor_;
+}
+
+const MysqlRequest& MysqlRequest::default_instance() {
+    if (default_instance_ == NULL) {
+        protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    }
+    return *default_instance_;
+}
+
+MysqlRequest* MysqlRequest::default_instance_ = NULL;
+
+MysqlRequest* MysqlRequest::New() const {
+    return new MysqlRequest;
+}
+
+void MysqlRequest::Clear() {
+    _has_error = false;
+    _buf.clear();
+}
+
+bool MysqlRequest::MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream*) {
+    LOG(WARNING) << "You're not supposed to parse a MysqlRequest";
+    return true;
+}
+
+void MysqlRequest::SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream*) const {
+    LOG(WARNING) << "You're not supposed to serialize a MysqlRequest";
+}
+
+::google::protobuf::uint8* MysqlRequest::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+    return target;
+}
+
+int MysqlRequest::ByteSize() const {
+    int total_size = _buf.size();
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _cached_size_ = total_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    return total_size;
+}
+
+void MysqlRequest::MergeFrom(const ::google::protobuf::Message& from) {
+    GOOGLE_CHECK_NE(&from, this);
+    const MysqlRequest* source =
+        ::google::protobuf::internal::dynamic_cast_if_available<const MysqlRequest*>(&from);
+    if (source == NULL) {
+        ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+    } else {
+        MergeFrom(*source);
+    }
+}
+
+void MysqlRequest::MergeFrom(const MysqlRequest& from) {
+    GOOGLE_CHECK_NE(&from, this);
+    _has_error = _has_error || from._has_error;
+    _buf.append(from._buf);
+}
+
+void MysqlRequest::CopyFrom(const ::google::protobuf::Message& from) {
+    if (&from == this)
+        return;
+    Clear();
+    MergeFrom(from);
+}
+
+void MysqlRequest::CopyFrom(const MysqlRequest& from) {
+    if (&from == this)
+        return;
+    Clear();
+    MergeFrom(from);
+}
+
+void MysqlRequest::Swap(MysqlRequest* other) {
+    if (other != this) {
+        _buf.swap(other->_buf);
+        std::swap(_has_error, other->_has_error);
+        std::swap(_cached_size_, other->_cached_size_);
+    }
+}
+
+bool MysqlRequest::SerializeTo(butil::IOBuf* buf) const {
+    if (_has_error) {
+        LOG(ERROR) << "Reject serialization due to error in AddCommand[V]";
+        return false;
+    }
+    *buf = _buf;
+    return true;
+}
+
+::google::protobuf::Metadata MysqlRequest::GetMetadata() const {
+    protobuf_AssignDescriptorsOnce();
+    ::google::protobuf::Metadata metadata;
+    metadata.descriptor = MysqlRequest_descriptor_;
+    metadata.reflection = NULL;
+    return metadata;
+}
+
+bool MysqlRequest::Query(const std::string& stmt) {
+    if (_has_error) {
+        return false;
+    }
+
+    const butil::Status st = MysqlMakeCommand(&_buf, COM_QUERY, stmt);
+    if (st.ok()) {
+        return true;
+    } else {
+        CHECK(st.ok()) << st;
+        _has_error = true;
+        return false;
+    }
+}
+
+void MysqlRequest::Print(std::ostream& os) const {
+    butil::IOBuf cp = _buf;
+    {
+        uint8_t buf[3];
+        cp.cutn(buf, 3);
+        os << "size:" << mysql_uint3korr(buf) << ",";
+    }
+    {
+        uint8_t buf;
+        cp.cut1((char*)&buf);
+        os << "sequence:" << (unsigned)buf << ",";
+    }
+    os << "payload(hex):";
+    while (!cp.empty()) {
+        uint8_t buf;
+        cp.cut1((char*)&buf);
+        os << std::hex << (unsigned)buf;
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const MysqlRequest& r) {
+    r.Print(os);
+    return os;
+}
+
+// ===================================================================
+
+#ifndef _MSC_VER
+#endif  // !_MSC_VER
+
+MysqlResponse::MysqlResponse() : ::google::protobuf::Message() {
+    SharedCtor();
+}
+
+void MysqlResponse::InitAsDefaultInstance() {}
+
+MysqlResponse::MysqlResponse(const MysqlResponse& from) : ::google::protobuf::Message() {
+    SharedCtor();
+    MergeFrom(from);
+}
+
+void MysqlResponse::SharedCtor() {
+    _other_replies = NULL;
+    _nreply = 0;
+    _cached_size_ = 0;
+}
+
+MysqlResponse::~MysqlResponse() {
+    SharedDtor();
+}
+
+void MysqlResponse::SharedDtor() {
+    if (this != default_instance_) {
+    }
+}
+
+void MysqlResponse::SetCachedSize(int size) const {
+    _cached_size_ = size;
+}
+const ::google::protobuf::Descriptor* MysqlResponse::descriptor() {
+    protobuf_AssignDescriptorsOnce();
+    return MysqlResponse_descriptor_;
+}
+
+const MysqlResponse& MysqlResponse::default_instance() {
+    if (default_instance_ == NULL) {
+        protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    }
+    return *default_instance_;
+}
+
+MysqlResponse* MysqlResponse::default_instance_ = NULL;
+
+MysqlResponse* MysqlResponse::New() const {
+    return new MysqlResponse;
+}
+
+void MysqlResponse::Clear() {}
+
+bool MysqlResponse::MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream*) {
+    LOG(WARNING) << "You're not supposed to parse a MysqlResponse";
+    return true;
+}
+
+void MysqlResponse::SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream*) const {
+    LOG(WARNING) << "You're not supposed to serialize a MysqlResponse";
+}
+
+::google::protobuf::uint8* MysqlResponse::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+    return target;
+}
+
+int MysqlResponse::ByteSize() const {
+    return _cached_size_;
+}
+
+void MysqlResponse::MergeFrom(const ::google::protobuf::Message& from) {
+    GOOGLE_CHECK_NE(&from, this);
+    const MysqlResponse* source =
+        ::google::protobuf::internal::dynamic_cast_if_available<const MysqlResponse*>(&from);
+    if (source == NULL) {
+        ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+    } else {
+        MergeFrom(*source);
+    }
+}
+
+void MysqlResponse::MergeFrom(const MysqlResponse& from) {
+    GOOGLE_CHECK_NE(&from, this);
+}
+
+void MysqlResponse::CopyFrom(const ::google::protobuf::Message& from) {
+    if (&from == this)
+        return;
+    Clear();
+    MergeFrom(from);
+}
+
+void MysqlResponse::CopyFrom(const MysqlResponse& from) {
+    if (&from == this)
+        return;
+    Clear();
+    MergeFrom(from);
+}
+
+bool MysqlResponse::IsInitialized() const {
+    return true;
+}
+
+void MysqlResponse::Swap(MysqlResponse* other) {
+    if (other != this) {
+        _first_reply.Swap(other->_first_reply);
+        std::swap(_other_replies, other->_other_replies);
+        _arena.swap(other->_arena);
+        std::swap(_nreply, other->_nreply);
+        std::swap(_cached_size_, other->_cached_size_);
+    }
+}
+
+::google::protobuf::Metadata MysqlResponse::GetMetadata() const {
+    protobuf_AssignDescriptorsOnce();
+    ::google::protobuf::Metadata metadata;
+    metadata.descriptor = MysqlResponse_descriptor_;
+    metadata.reflection = NULL;
+    return metadata;
+}
+
+// ===================================================================
+
+bool MysqlResponse::ConsumePartialIOBuf(butil::IOBuf& buf, const bool is_auth) {
+    bool is_multi;
+
+label_reparse:
+    size_t oldsize = buf.size();
+    if (reply_size() == 0) {
+        if (!_first_reply.ConsumePartialIOBuf(buf, &_arena, is_auth, &is_multi)) {
+            LOG(INFO) << "mysql reply parse error";
+            return false;
+        }
+
+        const size_t newsize = buf.size();
+        _cached_size_ += oldsize - newsize;
+        oldsize = newsize;
+        ++_nreply;
+    } else {
+        if (_nreply >= FLAGS_mysql_max_replies) {
+            LOG(ERROR) << "current max reply size is " << FLAGS_mysql_max_replies
+                       << ", use --mysql_max_replies=XXX to adjust";
+            return false;
+        }
+        if (_other_replies == NULL) {
+            _other_replies =
+                (MysqlReply*)_arena.allocate(sizeof(MysqlReply) * FLAGS_mysql_max_replies - 1);
+            if (_other_replies == NULL) {
+                LOG(ERROR) << "Fail to allocate MysqlReply";
+                return false;
+            }
+        }
+        new (&_other_replies[_nreply - 1]) MysqlReply;
+        if (!_other_replies[_nreply - 1].ConsumePartialIOBuf(buf, &_arena, is_auth, &is_multi)) {
+            LOG(INFO) << "mysql reply parse error";
+            return false;
+        }
+
+        const size_t newsize = buf.size();
+        _cached_size_ += oldsize - newsize;
+        oldsize = newsize;
+        ++_nreply;
+    }
+
+    if (oldsize > 0) {
+        goto label_reparse;
+    }
+
+    if (!is_multi) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const MysqlResponse& response) {
+    os << "\n-----MYSQL REPLY BEGIN-----\n";
+    if (response.reply_size() == 0) {
+        os << "<empty response>";
+    } else if (response.reply_size() == 1) {
+        os << response.reply(0);
+    } else {
+        for (int i = 0; i < response.reply_size(); ++i) {
+            os << "\nreply(" << i << ")----------";
+            os << response.reply(i);
+        }
+    }
+    os << "\n-----MYSQL REPLY END-----\n";
+
+    return os;
+}
+
+}  // namespace brpc

--- a/src/brpc/mysql.h
+++ b/src/brpc/mysql.h
@@ -1,0 +1,186 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Yang,Liming (yangliming01@baidu.com)
+
+#ifndef BRPC_MYSQL_H
+#define BRPC_MYSQL_H
+
+#include <string>
+#include <google/protobuf/stubs/common.h>
+
+#include <google/protobuf/generated_message_util.h>
+#include <google/protobuf/repeated_field.h>
+#include <google/protobuf/extension_set.h>
+#include <google/protobuf/generated_message_reflection.h>
+#include "google/protobuf/descriptor.pb.h"
+
+#include "butil/iobuf.h"
+#include "butil/strings/string_piece.h"
+#include "butil/arena.h"
+#include "brpc/mysql_reply.h"
+
+namespace brpc {
+// Request to mysql.
+// Notice that you can pipeline multiple commands in one request and sent
+// them to ONE mysql-server together.
+// Example:
+//   MysqlRequest request;
+//   request.Query("select * from table");
+//   MysqlResponse response;
+//   channel.CallMethod(NULL, &controller, &request, &response, NULL/*done*/);
+//   if (!cntl.Failed()) {
+//       LOG(INFO) << response.reply(0);
+//   }
+class MysqlRequest : public ::google::protobuf::Message {
+public:
+    MysqlRequest();
+    virtual ~MysqlRequest();
+    MysqlRequest(const MysqlRequest& from);
+    inline MysqlRequest& operator=(const MysqlRequest& from) {
+        CopyFrom(from);
+        return *this;
+    }
+    void Swap(MysqlRequest* other);
+
+    // Serialize the request into `buf'. Return true on success.
+    bool SerializeTo(butil::IOBuf* buf) const;
+
+    // Protobuf methods.
+    MysqlRequest* New() const;
+    void CopyFrom(const ::google::protobuf::Message& from);
+    void MergeFrom(const ::google::protobuf::Message& from);
+    void CopyFrom(const MysqlRequest& from);
+    void MergeFrom(const MysqlRequest& from);
+    void Clear();
+
+    int ByteSize() const;
+    bool MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream* input);
+    void SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream* output) const;
+    ::google::protobuf::uint8* SerializeWithCachedSizesToArray(
+        ::google::protobuf::uint8* output) const;
+    int GetCachedSize() const {
+        return _cached_size_;
+    }
+
+    static const ::google::protobuf::Descriptor* descriptor();
+    static const MysqlRequest& default_instance();
+    ::google::protobuf::Metadata GetMetadata() const;
+
+    bool Query(const std::string& stmt);
+
+    // True if previous AddCommand[V] failed.
+    bool has_error() const {
+        return _has_error;
+    }
+
+    void Print(std::ostream&) const;
+
+private:
+    void SharedCtor();
+    void SharedDtor();
+    void SetCachedSize(int size) const;
+
+    bool _has_error;            // previous AddCommand had error
+    butil::IOBuf _buf;          // the serialized request.
+    mutable int _cached_size_;  // ByteSize
+
+    friend void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_impl();
+    friend void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    friend void protobuf_AssignDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    friend void protobuf_ShutdownFile_baidu_2frpc_2fmysql_5fbase_2eproto();
+
+    void InitAsDefaultInstance();
+    static MysqlRequest* default_instance_;
+};
+
+// Response from Mysql.
+// Notice that a MysqlResponse instance may contain multiple replies
+// due to pipelining.
+class MysqlResponse : public ::google::protobuf::Message {
+public:
+    MysqlResponse();
+    virtual ~MysqlResponse();
+    MysqlResponse(const MysqlResponse& from);
+    inline MysqlResponse& operator=(const MysqlResponse& from) {
+        CopyFrom(from);
+        return *this;
+    }
+    void Swap(MysqlResponse* other);
+    // Parse and consume intact replies from the buf.
+    // Returns true on success, false otherwise.
+    bool ConsumePartialIOBuf(butil::IOBuf& buf, const bool is_auth = false);
+
+    // Number of replies in this response.
+    // (May have more than one reply due to pipeline)
+    int reply_size() const {
+        return _nreply;
+    }
+
+    const MysqlReply& reply(int index) const {
+        if (index < reply_size()) {
+            return (index == 0 ? _first_reply : _other_replies[index - 1]);
+        }
+        static MysqlReply mysql_nil;
+        return mysql_nil;
+    }
+    // implements Message ----------------------------------------------
+
+    MysqlResponse* New() const;
+    void CopyFrom(const ::google::protobuf::Message& from);
+    void MergeFrom(const ::google::protobuf::Message& from);
+    void CopyFrom(const MysqlResponse& from);
+    void MergeFrom(const MysqlResponse& from);
+    void Clear();
+    bool IsInitialized() const;
+
+    int ByteSize() const;
+    bool MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream* input);
+    void SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream* output) const;
+    ::google::protobuf::uint8* SerializeWithCachedSizesToArray(
+        ::google::protobuf::uint8* output) const;
+    int GetCachedSize() const {
+        return 0;
+    }
+
+    static const ::google::protobuf::Descriptor* descriptor();
+    static const MysqlResponse& default_instance();
+    ::google::protobuf::Metadata GetMetadata() const;
+
+private:
+    void SharedCtor();
+    void SharedDtor();
+    void SetCachedSize(int size) const;
+
+    MysqlReply _first_reply;
+    MysqlReply* _other_replies;
+    butil::Arena _arena;
+    int _nreply;
+    mutable int _cached_size_;
+
+    friend void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto_impl();
+    friend void protobuf_AddDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    friend void protobuf_AssignDesc_baidu_2frpc_2fmysql_5fbase_2eproto();
+    friend void protobuf_ShutdownFile_baidu_2frpc_2fmysql_5fbase_2eproto();
+
+    void InitAsDefaultInstance();
+    static MysqlResponse* default_instance_;
+};
+
+std::ostream& operator<<(std::ostream& os, const MysqlRequest&);
+std::ostream& operator<<(std::ostream& os, const MysqlResponse&);
+
+}  // namespace brpc
+
+#endif  // BRPC_MYSQL_H

--- a/src/brpc/mysql_command.cpp
+++ b/src/brpc/mysql_command.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2015 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Ge,Jun (gejun@baidu.com)
+
+#include "brpc/mysql_command.h"
+#include "butil/sys_byteorder.h"
+#include "butil/logging.h"  // LOG()
+#include <ios>
+
+namespace brpc {
+
+butil::Status MysqlMakeCommand(butil::IOBuf* outbuf,
+                               const MysqlCommandType type,
+                               const std::string& stmt,
+                               const uint8_t seq) {
+    if (outbuf == NULL || stmt.length() == 0) {
+        return butil::Status(EINVAL, "Param[outbuf] or [stmt] is NULL");
+    }
+    outbuf->clear();
+    butil::IOBuf payload;
+    payload.push_back(type);
+    payload.append(stmt);
+    uint32_t header = butil::ByteSwapToLE32(payload.size());
+    outbuf->append(&header, 3);
+    outbuf->push_back(seq);
+    outbuf->append(payload);
+    return butil::Status::OK();
+}
+
+
+}  // namespace brpc

--- a/src/brpc/mysql_command.h
+++ b/src/brpc/mysql_command.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Yang,Liming (yangliming01@baidu.com)
+
+#include "butil/iobuf.h"
+#include "butil/status.h"
+
+#ifndef BRPC_MYSQL_COMMAND_H
+#define BRPC_MYSQL_COMMAND_H
+namespace brpc {
+// mysql command types
+enum MysqlCommandType : unsigned char {
+    COM_SLEEP,
+    COM_QUIT,
+    COM_INIT_DB,
+    COM_QUERY,
+    COM_FIELD_LIST,
+    COM_CREATE_DB,
+    COM_DROP_DB,
+    COM_REFRESH,
+    COM_SHUTDOWN,
+    COM_STATISTICS,
+    COM_PROCESS_INFO,
+    COM_CONNECT,
+    COM_PROCESS_KILL,
+    COM_DEBUG,
+    COM_PING,
+    COM_TIME,
+    COM_DELAYED_INSERT,
+    COM_CHANGE_USER,
+    COM_BINLOG_DUMP,
+    COM_TABLE_DUMP,
+    COM_CONNECT_OUT,
+    COM_REGISTER_SLAVE,
+    COM_STMT_PREPARE,
+    COM_STMT_EXECUTE,
+    COM_STMT_SEND_LONG_DATA,
+    COM_STMT_CLOSE,
+    COM_STMT_RESET,
+    COM_SET_OPTION,
+    COM_STMT_FETCH,
+    COM_DAEMON,
+    COM_BINLOG_DUMP_GTID,
+    COM_RESET_CONNECTION,
+};
+
+butil::Status MysqlMakeCommand(butil::IOBuf* outbuf,
+                               const MysqlCommandType type,
+                               const std::string& stmt,
+                               const uint8_t seq = 0);
+
+}  // namespace brpc
+#endif

--- a/src/brpc/mysql_reply.cpp
+++ b/src/brpc/mysql_reply.cpp
@@ -1,0 +1,740 @@
+#include "brpc/mysql_reply.h"
+#include <ios>
+
+namespace brpc {
+
+#define MY_ERROR_RET(expr, message) \
+    do {                            \
+        if ((expr) == true) {       \
+            LOG(INFO) << message;   \
+            return false;           \
+        }                           \
+    } while (0)
+
+#define MY_ALLOC_CHECK(expr) MY_ERROR_RET(!(expr), "Fail to arena allocate")
+#define MY_PARSE_CHECK(expr) \
+    MY_ERROR_RET(!(expr), "Fail to parse mysql protocol")
+template <class Type>
+inline bool my_alloc_check(butil::Arena* arena, const size_t n,
+                           Type*& pointer) {
+    if (pointer == NULL) {
+        pointer = (Type*)arena->allocate(sizeof(Type) * n);
+        if (pointer == NULL) {
+            return false;
+        }
+        for (size_t i = 0; i < n; ++i) {
+            new (pointer + i) Type;
+        }
+    }
+    return true;
+}
+
+const char* MysqlFieldTypeToString(MysqlFieldType type) {
+    switch (type) {
+        case MYSQL_FIELD_TYPE_DECIMAL:
+        case MYSQL_FIELD_TYPE_TINY:
+            return "tiny";
+        case MYSQL_FIELD_TYPE_SHORT:
+            return "short";
+        case MYSQL_FIELD_TYPE_LONG:
+            return "long";
+        case MYSQL_FIELD_TYPE_FLOAT:
+            return "float";
+        case MYSQL_FIELD_TYPE_DOUBLE:
+            return "double";
+        case MYSQL_FIELD_TYPE_NULL:
+            return "null";
+        case MYSQL_FIELD_TYPE_TIMESTAMP:
+            return "timestamp";
+        case MYSQL_FIELD_TYPE_LONGLONG:
+            return "longlong";
+        case MYSQL_FIELD_TYPE_INT24:
+            return "int24";
+        case MYSQL_FIELD_TYPE_DATE:
+            return "date";
+        case MYSQL_FIELD_TYPE_TIME:
+            return "time";
+        case MYSQL_FIELD_TYPE_DATETIME:
+            return "datetime";
+        case MYSQL_FIELD_TYPE_YEAR:
+            return "year";
+        case MYSQL_FIELD_TYPE_NEWDATE:
+            return "new date";
+        case MYSQL_FIELD_TYPE_VARCHAR:
+            return "varchar";
+        case MYSQL_FIELD_TYPE_BIT:
+            return "bit";
+        case MYSQL_FIELD_TYPE_JSON:
+            return "json";
+        case MYSQL_FIELD_TYPE_NEWDECIMAL:
+            return "new decimal";
+        case MYSQL_FIELD_TYPE_ENUM:
+            return "enum";
+        case MYSQL_FIELD_TYPE_SET:
+            return "set";
+        case MYSQL_FIELD_TYPE_TINY_BLOB:
+            return "tiny blob";
+        case MYSQL_FIELD_TYPE_MEDIUM_BLOB:
+            return "blob";
+        case MYSQL_FIELD_TYPE_LONG_BLOB:
+            return "long blob";
+        case MYSQL_FIELD_TYPE_BLOB:
+            return "blob";
+        case MYSQL_FIELD_TYPE_VAR_STRING:
+            return "var string";
+        case MYSQL_FIELD_TYPE_STRING:
+            return "string";
+        case MYSQL_FIELD_TYPE_GEOMETRY:
+            return "geometry";
+        default:
+            return "Unknown Field Type";
+    }
+}
+
+const char* MysqlRspTypeToString(MysqlRspType type) {
+    switch (type) {
+        case MYSQL_RSP_OK:
+            return "ok";
+        case MYSQL_RSP_ERROR:
+            return "error";
+        case MYSQL_RSP_RESULTSET:
+            return "resultset";
+        case MYSQL_RSP_EOF:
+            return "eof";
+        case MYSQL_RSP_AUTH:
+            return "auth";
+        default:
+            return "Unknown Response Type";
+    }
+}
+
+bool ParseHeader(butil::IOBuf& buf, MysqlHeader* value) {
+    // check if the buf is contain a full package
+    uint8_t header[4];
+    const uint8_t* p = (const uint8_t*)buf.fetch(header, sizeof(header));
+    if (p == NULL) {
+        LOG(ERROR) << "fetch mysql protocol header failed";
+        return false;
+    }
+    uint32_t payload_size = mysql_uint3korr(p);
+    if (buf.size() < payload_size + 4) {
+        LOG(INFO) << "IOBuf not enough full mysql message buf size:"
+                  << buf.size() << " message size:" << payload_size + 4;
+        return false;
+    }
+
+    {
+        uint8_t tmp[3];
+        buf.cutn(tmp, sizeof(tmp));
+        value->payload_size = mysql_uint3korr(tmp);
+    }
+    {
+        uint8_t tmp;
+        buf.cut1((char*)&tmp);
+        value->seq = tmp;
+    }
+    return true;
+}
+bool ParseEncodeLength(butil::IOBuf& buf, uint64_t* value) {
+    uint8_t f;
+    buf.cut1((char*)&f);
+    if (f <= 250) {
+        *value = f;
+    } else if (f == 251) {
+        *value = 0;
+    } else if (f == 252) {
+        uint8_t tmp[2];
+        buf.cutn(tmp, sizeof(tmp));
+        *value = mysql_uint2korr(tmp);
+    } else if (f == 253) {
+        uint8_t tmp[3];
+        buf.cutn(tmp, sizeof(tmp));
+        *value = mysql_uint3korr(tmp);
+    } else if (f == 254) {
+        uint8_t tmp[8];
+        buf.cutn(tmp, sizeof(tmp));
+        *value = mysql_uint8korr(tmp);
+    }
+    return true;
+}
+
+bool MysqlReply::ConsumePartialIOBuf(butil::IOBuf& buf, butil::Arena* arena,
+                                     const bool is_auth, bool* is_multi) {
+    *is_multi = false;
+    uint8_t header[5];
+    const uint8_t* p = (const uint8_t*)buf.fetch(header, sizeof(header));
+    if (p == NULL) {
+        return false;
+    }
+    uint8_t type = _type == MYSQL_RSP_UNKNOWN ? p[4] : (uint8_t)_type;
+    if (is_auth && type != 0x00 && type != 0xFF) {
+        _type = MYSQL_RSP_AUTH;
+        Auth* auth = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, 1, auth));
+        MY_PARSE_CHECK(auth->parse(buf, arena));
+        _data.auth = auth;
+        return true;
+    }
+    if (type == 0x00) {
+        _type = MYSQL_RSP_OK;
+        Ok* ok = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, 1, ok));
+        MY_PARSE_CHECK(ok->parse(buf, arena));
+        _data.ok = ok;
+        *is_multi = _data.ok->status() & MYSQL_SERVER_MORE_RESULTS_EXISTS;
+    } else if (type == 0xFF) {
+        _type = MYSQL_RSP_ERROR;
+        Error* error = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, 1, error));
+        MY_PARSE_CHECK(error->parse(buf, arena));
+        _data.error = error;
+    } else if (type == 0xFE) {
+        _type = MYSQL_RSP_EOF;
+        Eof* eof = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, 1, eof));
+        MY_PARSE_CHECK(eof->parse(buf));
+        _data.eof = eof;
+        *is_multi = _data.eof->status() & MYSQL_SERVER_MORE_RESULTS_EXISTS;
+    } else if (type >= 0x01 && type <= 0xFA) {
+        _type = MYSQL_RSP_RESULTSET;
+        MY_ALLOC_CHECK(my_alloc_check(arena, 1, _data.result_set.var));
+        ResultSet& r = *_data.result_set.var;
+        // parse header
+        MY_PARSE_CHECK(r._header.parse(buf));
+        // parse colunms
+        MY_ALLOC_CHECK(
+            my_alloc_check(arena, r._header._column_number, r._columns));
+        for (uint64_t i = 0; i < r._header._column_number; ++i) {
+            MY_PARSE_CHECK(r._columns[i].parse(buf, arena));
+        }
+        // parse eof1
+        MY_PARSE_CHECK(r._eof1.parse(buf));
+        // parse row
+        Eof eof;
+        std::vector<Row*> rows;
+        bool is_first = true;
+        while (!eof.isEof(buf)) {
+            if (is_first) {
+                // we may reenter ConsumePartialIOBuf many times, check the last
+                // row
+                if (r._last != r._first) {
+                    MY_PARSE_CHECK(r._last->parseText(buf));
+                    for (uint64_t i = 0; i < r._header._column_number; ++i) {
+                        MY_PARSE_CHECK(r._last->_fields[i].parse(
+                            buf, r._columns + i, arena));
+                    }
+                }
+                is_first = false;
+                continue;
+            }
+
+            Row* row = NULL;
+            Field* fields = NULL;
+            MY_ALLOC_CHECK(my_alloc_check(arena, 1, row));
+            MY_ALLOC_CHECK(
+                my_alloc_check(arena, r._header._column_number, fields));
+            row->_fields = fields;
+            row->_field_number = r._header._column_number;
+            r._last->_next = row;
+            r._last = row;
+            // parse row and fields
+            MY_PARSE_CHECK(row->parseText(buf));
+            for (uint64_t i = 0; i < r._header._column_number; ++i) {
+                MY_PARSE_CHECK(fields[i].parse(buf, r._columns + i, arena));
+            }
+            // row number
+            ++r._row_number;
+        }
+        // parse eof2
+        MY_PARSE_CHECK(r._eof2.parse(buf));
+        *is_multi = r._eof2.status() & MYSQL_SERVER_MORE_RESULTS_EXISTS;
+    } else {
+        LOG(ERROR) << "Unknown Response Type";
+        return false;
+    }
+    return true;
+}
+
+void MysqlReply::Print(std::ostream& os) const {
+    if (_type == MYSQL_RSP_AUTH) {
+        const Auth& auth = *_data.auth;
+        os << "\nprotocol:" << (unsigned)auth._protocol
+           << "\nversion:" << auth._version.as_string()
+           << "\nthread_id:" << auth._thread_id
+           << "\nsalt:" << auth._salt.as_string()
+           << "\ncapacity:" << auth._capability
+           << "\nlanguage:" << (unsigned)auth._language
+           << "\nstatus:" << auth._status
+           << "\nextended_capacity:" << auth._extended_capability
+           << "\nauth_plugin_length:" << auth._auth_plugin_length
+           << "\nsalt2:" << auth._salt2.as_string()
+           << "\nauth_plugin:" << auth._auth_plugin.as_string();
+    } else if (_type == MYSQL_RSP_OK) {
+        const Ok& ok = *_data.ok;
+        os << "\naffect_row:" << ok._affect_row << "\nindex:" << ok._index
+           << "\nstatus:" << ok._status << "\nwarning:" << ok._warning
+           << "\nmessage:" << ok._msg.as_string();
+    } else if (_type == MYSQL_RSP_ERROR) {
+        const Error& err = *_data.error;
+        os << "\nerrcode:" << err._errcode
+           << "\nstatus:" << err._status.as_string()
+           << "\nmessage:" << err._msg.as_string();
+    } else if (_type == MYSQL_RSP_RESULTSET) {
+        const ResultSet& r = *_data.result_set.const_var;
+        os << "\nheader.column_number:" << r._header._column_number;
+        for (uint64_t i = 0; i < r._header._column_number; ++i) {
+            os << "\ncolumn[" << i
+               << "].catalog:" << r._columns[i]._catalog.as_string()
+               << "\ncolumn[" << i
+               << "].database:" << r._columns[i]._database.as_string()
+               << "\ncolumn[" << i
+               << "].table:" << r._columns[i]._table.as_string() << "\ncolumn["
+               << i
+               << "].origin_table:" << r._columns[i]._origin_table.as_string()
+               << "\ncolumn[" << i
+               << "].name:" << r._columns[i]._name.as_string() << "\ncolumn["
+               << i
+               << "].origin_name:" << r._columns[i]._origin_name.as_string()
+               << "\ncolumn[" << i
+               << "].collation:" << (uint16_t)r._columns[i]._collation
+               << "\ncolumn[" << i << "].length:" << r._columns[i]._length
+               << "\ncolumn[" << i << "].type:" << (unsigned)r._columns[i]._type
+               << "\ncolumn[" << i << "].flag:" << (unsigned)r._columns[i]._flag
+               << "\ncolumn[" << i
+               << "].decimal:" << (unsigned)r._columns[i]._decimal;
+        }
+        os << "\neof1.warning:" << r._eof1._warning;
+        os << "\neof1.status:" << r._eof1._status;
+        int n = 0;
+        for (const Row* row = r._first->_next; row != r._last->_next;
+             row = row->_next) {
+            os << "\nrow(" << n++ << "):";
+            for (uint64_t j = 0; j < r._header._column_number; ++j) {
+                switch (r._columns[j]._type) {
+                    case MYSQL_FIELD_TYPE_TINY:
+                        if (r._columns[j]._flag & MYSQL_UNSIGNED_FLAG) {
+                            os << row->field(j).tiny();
+                        } else {
+                            os << row->field(j).stiny();
+                        }
+                        break;
+                    case MYSQL_FIELD_TYPE_SHORT:
+                    case MYSQL_FIELD_TYPE_YEAR:
+                        if (r._columns[j]._flag & MYSQL_UNSIGNED_FLAG) {
+                            os << row->field(j).small();
+                        } else {
+                            os << row->field(j).ssmall();
+                        }
+                        break;
+                    case MYSQL_FIELD_TYPE_INT24:
+                    case MYSQL_FIELD_TYPE_LONG:
+                        if (r._columns[j]._flag & MYSQL_UNSIGNED_FLAG) {
+                            os << row->field(j).integer();
+                        } else {
+                            os << row->field(j).sinteger();
+                        }
+                        break;
+                    case MYSQL_FIELD_TYPE_LONGLONG:
+                        if (r._columns[j]._flag & MYSQL_UNSIGNED_FLAG) {
+                            os << row->field(j).bigint();
+                        } else {
+                            os << row->field(j).sbigint();
+                        }
+                        break;
+                    case MYSQL_FIELD_TYPE_FLOAT:
+                        os << row->field(j).float32();
+                        break;
+                    case MYSQL_FIELD_TYPE_DOUBLE:
+                        os << row->field(j).float64();
+                        break;
+                    case MYSQL_FIELD_TYPE_DECIMAL:
+                    case MYSQL_FIELD_TYPE_NEWDECIMAL:
+                    case MYSQL_FIELD_TYPE_VARCHAR:
+                    case MYSQL_FIELD_TYPE_BIT:
+                    case MYSQL_FIELD_TYPE_ENUM:
+                    case MYSQL_FIELD_TYPE_SET:
+                    case MYSQL_FIELD_TYPE_TINY_BLOB:
+                    case MYSQL_FIELD_TYPE_MEDIUM_BLOB:
+                    case MYSQL_FIELD_TYPE_LONG_BLOB:
+                    case MYSQL_FIELD_TYPE_BLOB:
+                    case MYSQL_FIELD_TYPE_VAR_STRING:
+                    case MYSQL_FIELD_TYPE_STRING:
+                    case MYSQL_FIELD_TYPE_GEOMETRY:
+                    case MYSQL_FIELD_TYPE_JSON:
+                    case MYSQL_FIELD_TYPE_TIME:
+                    case MYSQL_FIELD_TYPE_DATE:
+                    case MYSQL_FIELD_TYPE_NEWDATE:
+                    case MYSQL_FIELD_TYPE_TIMESTAMP:
+                    case MYSQL_FIELD_TYPE_DATETIME:
+                        os << row->field(j).string();
+                        break;
+                    default:
+                        os << "Unknown field type";
+                }
+                os << "\t";
+            }
+        }
+        os << "\neof2.warning:" << r._eof2._warning;
+        os << "\neof2.status:" << r._eof2._status;
+    } else if (_type == MYSQL_RSP_EOF) {
+        const Eof& e = *_data.eof;
+        os << "\nwarning:" << e._warning << "\nstatus:" << e._status;
+    } else {
+        os << "Unknown response type";
+    }
+}
+
+bool MysqlReply::Auth::parse(butil::IOBuf& buf, butil::Arena* arena) {
+    if (is_parsed()) {
+        return true;
+    }
+    const std::string delim(1, 0x00);
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+    buf.cut1((char*)&_protocol);
+    {
+        butil::IOBuf version;
+        buf.cut_until(&version, delim);
+        char* d = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, version.size(), d));
+        version.copy_to(d);
+        _version.set(d, version.size());
+    }
+    {
+        uint8_t tmp[4];
+        buf.cutn(tmp, sizeof(tmp));
+        _thread_id = mysql_uint4korr(tmp);
+    }
+    {
+        butil::IOBuf salt;
+        buf.cut_until(&salt, delim);
+        char* d = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, salt.size(), d));
+        salt.copy_to(d);
+        _salt.set(d, salt.size());
+    }
+    {
+        uint8_t tmp[2];
+        buf.cutn(&tmp, sizeof(tmp));
+        _capability = mysql_uint2korr(tmp);
+    }
+    buf.cut1((char*)&_language);
+    {
+        uint8_t tmp[2];
+        buf.cutn(tmp, sizeof(tmp));
+        _status = mysql_uint2korr(tmp);
+    }
+    {
+        uint8_t tmp[2];
+        buf.cutn(tmp, sizeof(tmp));
+        _extended_capability = mysql_uint2korr(tmp);
+    }
+    buf.cut1((char*)&_auth_plugin_length);
+    buf.pop_front(10);
+    {
+        butil::IOBuf salt2;
+        buf.cut_until(&salt2, delim);
+        char* d = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, salt2.size(), d));
+        salt2.copy_to(d);
+        _salt2.set(d, salt2.size());
+    }
+    {
+        char* d = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, _auth_plugin_length, d));
+        buf.cutn(d, _auth_plugin_length);
+        _auth_plugin.set(d, _auth_plugin_length);
+    }
+    buf.clear();  // consume all buf
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::ResultSetHeader::parse(butil::IOBuf& buf) {
+    if (is_parsed()) {
+        return true;
+    }
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+    uint64_t old_size, new_size;
+    old_size = buf.size();
+    ParseEncodeLength(buf, &_column_number);
+    new_size = buf.size();
+    if (old_size - new_size < header.payload_size) {
+        ParseEncodeLength(buf, &_extra_msg);
+    } else {
+        _extra_msg = 0;
+    }
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::Column::parse(butil::IOBuf& buf, butil::Arena* arena) {
+    if (is_parsed()) {
+        return true;
+    }
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+
+    uint64_t len;
+    ParseEncodeLength(buf, &len);
+    char* catalog = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, catalog));
+    buf.cutn(catalog, len);
+    _catalog.set(catalog, len);
+
+    ParseEncodeLength(buf, &len);
+    char* database = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, database));
+    buf.cutn(database, len);
+    _database.set(database, len);
+
+    ParseEncodeLength(buf, &len);
+    char* table = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, table));
+    buf.cutn(table, len);
+    _table.set(table, len);
+
+    ParseEncodeLength(buf, &len);
+    char* origin_table = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, origin_table));
+    buf.cutn(origin_table, len);
+    _origin_table.set(origin_table, len);
+
+    ParseEncodeLength(buf, &len);
+    char* name = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, name));
+    buf.cutn(name, len);
+    _name.set(name, len);
+
+    ParseEncodeLength(buf, &len);
+    char* origin_name = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, origin_name));
+    buf.cutn(origin_name, len);
+    _origin_name.set(origin_name, len);
+    buf.pop_front(1);
+    {
+        uint8_t tmp[2];
+        buf.cutn(tmp, sizeof(tmp));
+        _collation = (MysqlCollation)mysql_uint2korr(tmp);
+    }
+    {
+        uint8_t tmp[4];
+        buf.cutn(tmp, sizeof(tmp));
+        _length = mysql_uint4korr(tmp);
+    }
+    buf.cut1((char*)&_type);
+    {
+        uint8_t tmp[2];
+        buf.cutn(tmp, sizeof(tmp));
+        _flag = (MysqlFieldFlag)mysql_uint2korr(tmp);
+    }
+    buf.cut1((char*)&_decimal);
+    buf.pop_front(2);
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::Ok::parse(butil::IOBuf& buf, butil::Arena* arena) {
+    if (is_parsed()) {
+        return true;
+    }
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+
+    uint64_t len, old_size, new_size;
+    old_size = buf.size();
+    buf.pop_front(1);
+
+    ParseEncodeLength(buf, &len);
+    _affect_row = len;
+
+    ParseEncodeLength(buf, &len);
+    _index = len;
+
+    buf.cutn(&_status, 2);
+    buf.cutn(&_warning, 2);
+
+    new_size = buf.size();
+    if (old_size - new_size < header.payload_size) {
+        len = header.payload_size - (old_size - new_size);
+        char* msg = NULL;
+        MY_ALLOC_CHECK(my_alloc_check(arena, len, msg));
+        buf.cutn(msg, len);
+        _msg.set(msg, len);
+        // buf.pop_front(1);  // Null
+    }
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::Eof::isEof(const butil::IOBuf& buf) {
+    uint8_t tmp[5];
+    const uint8_t* p = (const uint8_t*)buf.fetch(tmp, sizeof(tmp));
+    uint8_t type = p[4];
+    if (type == MYSQL_RSP_EOF) {
+        buf.copy_to(&_warning, 2, 5);
+        buf.copy_to(&_status, 2, 7);
+        return true;
+    }
+    return false;
+}
+
+bool MysqlReply::Eof::parse(butil::IOBuf& buf) {
+    if (is_parsed()) {
+        return true;
+    }
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+    buf.pop_front(1);
+    buf.cutn(&_warning, 2);
+    buf.cutn(&_status, 2);
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::Error::parse(butil::IOBuf& buf, butil::Arena* arena) {
+    if (is_parsed()) {
+        return true;
+    }
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+    buf.pop_front(1);  // 0xFF
+    {
+        uint8_t tmp[2];
+        buf.cutn(tmp, sizeof(tmp));
+        _errcode = mysql_uint2korr(tmp);
+    }
+    buf.pop_front(1);  // '#'
+    // 5 byte server status
+    char* status = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, 5, status));
+    buf.cutn(status, 5);
+    _status.set(status, 5);
+    // error message, Null-Terminated string
+    uint64_t len = header.payload_size - 9;
+    char* msg = NULL;
+    MY_ALLOC_CHECK(my_alloc_check(arena, len, msg));
+    buf.cutn(msg, len);
+    _msg.set(msg, len);
+    // buf.pop_front(1);  // Null
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::Row::parseText(butil::IOBuf& buf) {
+    if (is_parsed()) {
+        return true;
+    }
+    MysqlHeader header;
+    if (!ParseHeader(buf, &header)) {
+        return false;
+    }
+    set_parsed();
+    return true;
+}
+
+bool MysqlReply::Field::parse(butil::IOBuf& buf,
+                              const MysqlReply::Column* column,
+                              butil::Arena* arena) {
+    if (is_parsed()) {
+        return true;
+    }
+    uint64_t len;
+    ParseEncodeLength(buf, &len);
+    // is it null?
+    if (len == 0 && !(column->_flag & MYSQL_NOT_NULL_FLAG)) {
+        _type = MYSQL_FIELD_TYPE_NULL;
+        set_parsed();
+        return true;
+    }
+    // field type
+    _type = column->_type;
+    // is unsigned flag set
+    _is_unsigned = column->_flag & MYSQL_UNSIGNED_FLAG;
+    // field is not null
+    butil::IOBuf str;
+    buf.cutn(&str, len);
+    switch (_type) {
+        case MYSQL_FIELD_TYPE_TINY:
+            if (column->_flag & MYSQL_UNSIGNED_FLAG) {
+                std::istringstream(str.to_string()) >> _data.tiny;
+            } else {
+                std::istringstream(str.to_string()) >> _data.stiny;
+            }
+            break;
+        case MYSQL_FIELD_TYPE_SHORT:
+        case MYSQL_FIELD_TYPE_YEAR:
+            if (column->_flag & MYSQL_UNSIGNED_FLAG) {
+                std::istringstream(str.to_string()) >> _data.small;
+            } else {
+                std::istringstream(str.to_string()) >> _data.ssmall;
+            }
+            break;
+        case MYSQL_FIELD_TYPE_INT24:
+        case MYSQL_FIELD_TYPE_LONG:
+            if (column->_flag & MYSQL_UNSIGNED_FLAG) {
+                std::istringstream(str.to_string()) >> _data.integer;
+            } else {
+                std::istringstream(str.to_string()) >> _data.sinteger;
+            }
+            break;
+        case MYSQL_FIELD_TYPE_LONGLONG:
+            if (column->_flag & MYSQL_UNSIGNED_FLAG) {
+                std::istringstream(str.to_string()) >> _data.bigint;
+            } else {
+                std::istringstream(str.to_string()) >> _data.sbigint;
+            }
+            break;
+        case MYSQL_FIELD_TYPE_FLOAT:
+            std::istringstream(str.to_string()) >> _data.float32;
+            break;
+        case MYSQL_FIELD_TYPE_DOUBLE:
+            std::istringstream(str.to_string()) >> _data.float64;
+            break;
+        case MYSQL_FIELD_TYPE_DECIMAL:
+        case MYSQL_FIELD_TYPE_NEWDECIMAL:
+        case MYSQL_FIELD_TYPE_VARCHAR:
+        case MYSQL_FIELD_TYPE_BIT:
+        case MYSQL_FIELD_TYPE_ENUM:
+        case MYSQL_FIELD_TYPE_SET:
+        case MYSQL_FIELD_TYPE_TINY_BLOB:
+        case MYSQL_FIELD_TYPE_MEDIUM_BLOB:
+        case MYSQL_FIELD_TYPE_LONG_BLOB:
+        case MYSQL_FIELD_TYPE_BLOB:
+        case MYSQL_FIELD_TYPE_VAR_STRING:
+        case MYSQL_FIELD_TYPE_STRING:
+        case MYSQL_FIELD_TYPE_GEOMETRY:
+        case MYSQL_FIELD_TYPE_JSON:
+        case MYSQL_FIELD_TYPE_TIME:
+        case MYSQL_FIELD_TYPE_DATE:
+        case MYSQL_FIELD_TYPE_NEWDATE:
+        case MYSQL_FIELD_TYPE_TIMESTAMP:
+        case MYSQL_FIELD_TYPE_DATETIME: {
+            char* d = NULL;
+            MY_ALLOC_CHECK(my_alloc_check(arena, len, d));
+            str.copy_to(d);
+            _data.str.set(d, len);
+        } break;
+        default:
+            LOG(ERROR) << "Unknown field type";
+            set_parsed();
+            return false;
+    }
+    set_parsed();
+    return true;
+}
+
+}  // namespace brpc

--- a/src/brpc/mysql_reply.h
+++ b/src/brpc/mysql_reply.h
@@ -1,0 +1,1010 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Yang,Liming (yangliming01@baidu.com)
+
+#ifndef BRPC_MYSQL_UTIL_H
+#define BRPC_MYSQL_UTIL_H
+
+#include "butil/iobuf.h"  // butil::IOBuf
+#include "butil/arena.h"
+#include "butil/sys_byteorder.h"
+#include "butil/logging.h"  // LOG()
+
+namespace brpc {
+
+class CheckParsed {
+public:
+    CheckParsed() : _is_parsed(false) {}
+    bool is_parsed() const {
+        return _is_parsed;
+    }
+    void set_parsed() {
+        _is_parsed = true;
+    }
+
+private:
+    bool _is_parsed;
+};
+
+struct MysqlHeader {
+    uint32_t payload_size;
+    uint32_t seq;
+};
+
+enum MysqlRspType : uint8_t {
+    MYSQL_RSP_OK = 0x00,
+    MYSQL_RSP_ERROR = 0xFF,
+    MYSQL_RSP_RESULTSET = 0x01,
+    MYSQL_RSP_EOF = 0xFE,
+    MYSQL_RSP_AUTH = 0xFB,     // add for mysql auth
+    MYSQL_RSP_UNKNOWN = 0xFC,  // add for other case
+};
+
+enum MysqlFieldType : uint8_t {
+    MYSQL_FIELD_TYPE_DECIMAL = 0x00,
+    MYSQL_FIELD_TYPE_TINY = 0x01,
+    MYSQL_FIELD_TYPE_SHORT = 0x02,
+    MYSQL_FIELD_TYPE_LONG = 0x03,
+    MYSQL_FIELD_TYPE_FLOAT = 0x04,
+    MYSQL_FIELD_TYPE_DOUBLE = 0x05,
+    MYSQL_FIELD_TYPE_NULL = 0x06,
+    MYSQL_FIELD_TYPE_TIMESTAMP = 0x07,
+    MYSQL_FIELD_TYPE_LONGLONG = 0x08,
+    MYSQL_FIELD_TYPE_INT24 = 0x09,
+    MYSQL_FIELD_TYPE_DATE = 0x0A,
+    MYSQL_FIELD_TYPE_TIME = 0x0B,
+    MYSQL_FIELD_TYPE_DATETIME = 0x0C,
+    MYSQL_FIELD_TYPE_YEAR = 0x0D,
+    MYSQL_FIELD_TYPE_NEWDATE = 0x0E,
+    MYSQL_FIELD_TYPE_VARCHAR = 0x0F,
+    MYSQL_FIELD_TYPE_BIT = 0x10,
+    MYSQL_FIELD_TYPE_JSON = 0xF5,
+    MYSQL_FIELD_TYPE_NEWDECIMAL = 0xF6,
+    MYSQL_FIELD_TYPE_ENUM = 0xF7,
+    MYSQL_FIELD_TYPE_SET = 0xF8,
+    MYSQL_FIELD_TYPE_TINY_BLOB = 0xF9,
+    MYSQL_FIELD_TYPE_MEDIUM_BLOB = 0xFA,
+    MYSQL_FIELD_TYPE_LONG_BLOB = 0xFB,
+    MYSQL_FIELD_TYPE_BLOB = 0xFC,
+    MYSQL_FIELD_TYPE_VAR_STRING = 0xFD,
+    MYSQL_FIELD_TYPE_STRING = 0xFE,
+    MYSQL_FIELD_TYPE_GEOMETRY = 0xFF,
+};
+
+enum MysqlFieldFlag : uint16_t {
+    MYSQL_NOT_NULL_FLAG = 0x0001,
+    MYSQL_PRI_KEY_FLAG = 0x0002,
+    MYSQL_UNIQUE_KEY_FLAG = 0x0004,
+    MYSQL_MULTIPLE_KEY_FLAG = 0x0008,
+    MYSQL_BLOB_FLAG = 0x0010,
+    MYSQL_UNSIGNED_FLAG = 0x0020,
+    MYSQL_ZEROFILL_FLAG = 0x0040,
+    MYSQL_BINARY_FLAG = 0x0080,
+    MYSQL_ENUM_FLAG = 0x0100,
+    MYSQL_AUTO_INCREMENT_FLAG = 0x0200,
+    MYSQL_TIMESTAMP_FLAG = 0x0400,
+    MYSQL_SET_FLAG = 0x0800,
+};
+
+enum MysqlServerStatus : uint16_t {
+    MYSQL_SERVER_STATUS_IN_TRANS = 1,
+    MYSQL_SERVER_STATUS_AUTOCOMMIT = 2,   /* Server in auto_commit mode */
+    MYSQL_SERVER_MORE_RESULTS_EXISTS = 8, /* Multi query - next query exists */
+    MYSQL_SERVER_QUERY_NO_GOOD_INDEX_USED = 16,
+    MYSQL_SERVER_QUERY_NO_INDEX_USED = 32,
+    /**
+      The server was able to fulfill the clients request and opened a
+      read-only non-scrollable cursor for a query. This flag comes
+      in reply to COM_STMT_EXECUTE and COM_STMT_FETCH commands.
+    */
+    MYSQL_SERVER_STATUS_CURSOR_EXISTS = 64,
+    /**
+      This flag is sent when a read-only cursor is exhausted, in reply to
+      COM_STMT_FETCH command.
+    */
+    MYSQL_SERVER_STATUS_LAST_ROW_SENT = 128,
+    MYSQL_SERVER_STATUS_DB_DROPPED = 256, /* A database was dropped */
+    MYSQL_SERVER_STATUS_NO_BACKSLASH_ESCAPES = 512,
+    /**
+      Sent to the client if after a prepared statement reprepare
+      we discovered that the new statement returns a different
+      number of result set columns.
+    */
+    MYSQL_SERVER_STATUS_METADATA_CHANGED = 1024,
+    MYSQL_SERVER_QUERY_WAS_SLOW = 2048,
+
+    /**
+      To mark ResultSet containing output parameter values.
+    */
+    MYSQL_SERVER_PS_OUT_PARAMS = 4096,
+
+    /**
+      Set at the same time as MYSQL_SERVER_STATUS_IN_TRANS if the started
+      multi-statement transaction is a read-only transaction. Cleared
+      when the transaction commits or aborts. Since this flag is sent
+      to clients in OK and EOF packets, the flag indicates the
+      transaction status at the end of command execution.
+    */
+    MYSQL_SERVER_STATUS_IN_TRANS_READONLY = 8192,
+    MYSQL_SERVER_SESSION_STATE_CHANGED = 1UL << 14,
+};
+// Msql Collation
+enum MysqlCollation : uint16_t {
+    MYSQL_big5_chinese_ci = 1,
+    MYSQL_latin2_czech_cs = 2,
+    MYSQL_dec8_swedish_ci = 3,
+    MYSQL_cp850_general_ci = 4,
+    MYSQL_latin1_german1_ci = 5,
+    MYSQL_hp8_english_ci = 6,
+    MYSQL_koi8r_general_ci = 7,
+    MYSQL_latin1_swedish_ci = 8,
+    MYSQL_latin2_general_ci = 9,
+    MYSQL_swe7_swedish_ci = 10,
+    MYSQL_ascii_general_ci = 11,
+    MYSQL_ujis_japanese_ci = 12,
+    MYSQL_sjis_japanese_ci = 13,
+    MYSQL_cp1251_bulgarian_ci = 14,
+    MYSQL_latin1_danish_ci = 15,
+    MYSQL_hebrew_general_ci = 16,
+    MYSQL_tis620_thai_ci = 18,
+    MYSQL_euckr_korean_ci = 19,
+    MYSQL_latin7_estonian_cs = 20,
+    MYSQL_latin2_hungarian_ci = 21,
+    MYSQL_koi8u_general_ci = 22,
+    MYSQL_cp1251_ukrainian_ci = 23,
+    MYSQL_gb2312_chinese_ci = 24,
+    MYSQL_greek_general_ci = 25,
+    MYSQL_cp1250_general_ci = 26,
+    MYSQL_latin2_croatian_ci = 27,
+    MYSQL_gbk_chinese_ci = 28,
+    MYSQL_cp1257_lithuanian_ci = 29,
+    MYSQL_latin5_turkish_ci = 30,
+    MYSQL_latin1_german2_ci = 31,
+    MYSQL_armscii8_general_ci = 32,
+    MYSQL_utf8_general_ci = 33,
+    MYSQL_cp1250_czech_cs = 34,
+    MYSQL_ucs2_general_ci = 35,
+    MYSQL_cp866_general_ci = 36,
+    MYSQL_keybcs2_general_ci = 37,
+    MYSQL_macce_general_ci = 38,
+    MYSQL_macroman_general_ci = 39,
+    MYSQL_cp852_general_ci = 40,
+    MYSQL_latin7_general_ci = 41,
+    MYSQL_latin7_general_cs = 42,
+    MYSQL_macce_bin = 43,
+    MYSQL_cp1250_croatian_ci = 44,
+    MYSQL_utf8mb4_general_ci = 45,
+    MYSQL_utf8mb4_bin = 46,
+    MYSQL_latin1_bin = 47,
+    MYSQL_latin1_general_ci = 48,
+    MYSQL_latin1_general_cs = 49,
+    MYSQL_cp1251_bin = 50,
+    MYSQL_cp1251_general_ci = 51,
+    MYSQL_cp1251_general_cs = 52,
+    MYSQL_macroman_bin = 53,
+    MYSQL_utf16_general_ci = 54,
+    MYSQL_utf16_bin = 55,
+    MYSQL_utf16le_general_ci = 56,
+    MYSQL_cp1256_general_ci = 57,
+    MYSQL_cp1257_bin = 58,
+    MYSQL_cp1257_general_ci = 59,
+    MYSQL_utf32_general_ci = 60,
+    MYSQL_utf32_bin = 61,
+    MYSQL_utf16le_bin = 62,
+    MYSQL_binary = 63,
+    MYSQL_armscii8_bin = 64,
+    MYSQL_ascii_bin = 65,
+    MYSQL_cp1250_bin = 66,
+    MYSQL_cp1256_bin = 67,
+    MYSQL_cp866_bin = 68,
+    MYSQL_dec8_bin = 69,
+    MYSQL_greek_bin = 70,
+    MYSQL_hebrew_bin = 71,
+    MYSQL_hp8_bin = 72,
+    MYSQL_keybcs2_bin = 73,
+    MYSQL_koi8r_bin = 74,
+    MYSQL_koi8u_bin = 75,
+    MYSQL_latin2_bin = 77,
+    MYSQL_latin5_bin = 78,
+    MYSQL_latin7_bin = 79,
+    MYSQL_cp850_bin = 80,
+    MYSQL_cp852_bin = 81,
+    MYSQL_swe7_bin = 82,
+    MYSQL_utf8_bin = 83,
+    MYSQL_big5_bin = 84,
+    MYSQL_euckr_bin = 85,
+    MYSQL_gb2312_bin = 86,
+    MYSQL_gbk_bin = 87,
+    MYSQL_sjis_bin = 88,
+    MYSQL_tis620_bin = 89,
+    MYSQL_ucs2_bin = 90,
+    MYSQL_ujis_bin = 91,
+    MYSQL_geostd8_general_ci = 92,
+    MYSQL_geostd8_bin = 93,
+    MYSQL_latin1_spanish_ci = 94,
+    MYSQL_cp932_japanese_ci = 95,
+    MYSQL_cp932_bin = 96,
+    MYSQL_eucjpms_japanese_ci = 97,
+    MYSQL_eucjpms_bin = 98,
+    MYSQL_cp1250_polish_ci = 99,
+    MYSQL_utf16_unicode_ci = 101,
+    MYSQL_utf16_icelandic_ci = 102,
+    MYSQL_utf16_latvian_ci = 103,
+    MYSQL_utf16_romanian_ci = 104,
+    MYSQL_utf16_slovenian_ci = 105,
+    MYSQL_utf16_polish_ci = 106,
+    MYSQL_utf16_estonian_ci = 107,
+    MYSQL_utf16_spanish_ci = 108,
+    MYSQL_utf16_swedish_ci = 109,
+    MYSQL_utf16_turkish_ci = 110,
+    MYSQL_utf16_czech_ci = 111,
+    MYSQL_utf16_danish_ci = 112,
+    MYSQL_utf16_lithuanian_ci = 113,
+    MYSQL_utf16_slovak_ci = 114,
+    MYSQL_utf16_spanish2_ci = 115,
+    MYSQL_utf16_roman_ci = 116,
+    MYSQL_utf16_persian_ci = 117,
+    MYSQL_utf16_esperanto_ci = 118,
+    MYSQL_utf16_hungarian_ci = 119,
+    MYSQL_utf16_sinhala_ci = 120,
+    MYSQL_utf16_german2_ci = 121,
+    MYSQL_utf16_croatian_ci = 122,
+    MYSQL_utf16_unicode_520_ci = 123,
+    MYSQL_utf16_vietnamese_ci = 124,
+    MYSQL_ucs2_unicode_ci = 128,
+    MYSQL_ucs2_icelandic_ci = 129,
+    MYSQL_ucs2_latvian_ci = 130,
+    MYSQL_ucs2_romanian_ci = 131,
+    MYSQL_ucs2_slovenian_ci = 132,
+    MYSQL_ucs2_polish_ci = 133,
+    MYSQL_ucs2_estonian_ci = 134,
+    MYSQL_ucs2_spanish_ci = 135,
+    MYSQL_ucs2_swedish_ci = 136,
+    MYSQL_ucs2_turkish_ci = 137,
+    MYSQL_ucs2_czech_ci = 138,
+    MYSQL_ucs2_danish_ci = 139,
+    MYSQL_ucs2_lithuanian_ci = 140,
+    MYSQL_ucs2_slovak_ci = 141,
+    MYSQL_ucs2_spanish2_ci = 142,
+    MYSQL_ucs2_roman_ci = 143,
+    MYSQL_ucs2_persian_ci = 144,
+    MYSQL_ucs2_esperanto_ci = 145,
+    MYSQL_ucs2_hungarian_ci = 146,
+    MYSQL_ucs2_sinhala_ci = 147,
+    MYSQL_ucs2_german2_ci = 148,
+    MYSQL_ucs2_croatian_ci = 149,
+    MYSQL_ucs2_unicode_520_ci = 150,
+    MYSQL_ucs2_vietnamese_ci = 151,
+    MYSQL_ucs2_general_mysql500_ci = 159,
+    MYSQL_utf32_unicode_ci = 160,
+    MYSQL_utf32_icelandic_ci = 161,
+    MYSQL_utf32_latvian_ci = 162,
+    MYSQL_utf32_romanian_ci = 163,
+    MYSQL_utf32_slovenian_ci = 164,
+    MYSQL_utf32_polish_ci = 165,
+    MYSQL_utf32_estonian_ci = 166,
+    MYSQL_utf32_spanish_ci = 167,
+    MYSQL_utf32_swedish_ci = 168,
+    MYSQL_utf32_turkish_ci = 169,
+    MYSQL_utf32_czech_ci = 170,
+    MYSQL_utf32_danish_ci = 171,
+    MYSQL_utf32_lithuanian_ci = 172,
+    MYSQL_utf32_slovak_ci = 173,
+    MYSQL_utf32_spanish2_ci = 174,
+    MYSQL_utf32_roman_ci = 175,
+    MYSQL_utf32_persian_ci = 176,
+    MYSQL_utf32_esperanto_ci = 177,
+    MYSQL_utf32_hungarian_ci = 178,
+    MYSQL_utf32_sinhala_ci = 179,
+    MYSQL_utf32_german2_ci = 180,
+    MYSQL_utf32_croatian_ci = 181,
+    MYSQL_utf32_unicode_520_ci = 182,
+    MYSQL_utf32_vietnamese_ci = 183,
+    MYSQL_utf8_unicode_ci = 192,
+    MYSQL_utf8_icelandic_ci = 193,
+    MYSQL_utf8_latvian_ci = 194,
+    MYSQL_utf8_romanian_ci = 195,
+    MYSQL_utf8_slovenian_ci = 196,
+    MYSQL_utf8_polish_ci = 197,
+    MYSQL_utf8_estonian_ci = 198,
+    MYSQL_utf8_spanish_ci = 199,
+    MYSQL_utf8_swedish_ci = 200,
+    MYSQL_utf8_turkish_ci = 201,
+    MYSQL_utf8_czech_ci = 202,
+    MYSQL_utf8_danish_ci = 203,
+    MYSQL_utf8_lithuanian_ci = 204,
+    MYSQL_utf8_slovak_ci = 205,
+    MYSQL_utf8_spanish2_ci = 206,
+    MYSQL_utf8_roman_ci = 207,
+    MYSQL_utf8_persian_ci = 208,
+    MYSQL_utf8_esperanto_ci = 209,
+    MYSQL_utf8_hungarian_ci = 210,
+    MYSQL_utf8_sinhala_ci = 211,
+    MYSQL_utf8_german2_ci = 212,
+    MYSQL_utf8_croatian_ci = 213,
+    MYSQL_utf8_unicode_520_ci = 214,
+    MYSQL_utf8_vietnamese_ci = 215,
+    MYSQL_utf8_general_mysql500_ci = 223,
+    MYSQL_utf8mb4_unicode_ci = 224,
+    MYSQL_utf8mb4_icelandic_ci = 225,
+    MYSQL_utf8mb4_latvian_ci = 226,
+    MYSQL_utf8mb4_romanian_ci = 227,
+    MYSQL_utf8mb4_slovenian_ci = 228,
+    MYSQL_utf8mb4_polish_ci = 229,
+    MYSQL_utf8mb4_estonian_ci = 230,
+    MYSQL_utf8mb4_spanish_ci = 231,
+    MYSQL_utf8mb4_swedish_ci = 232,
+    MYSQL_utf8mb4_turkish_ci = 233,
+    MYSQL_utf8mb4_czech_ci = 234,
+    MYSQL_utf8mb4_danish_ci = 235,
+    MYSQL_utf8mb4_lithuanian_ci = 236,
+    MYSQL_utf8mb4_slovak_ci = 237,
+    MYSQL_utf8mb4_spanish2_ci = 238,
+    MYSQL_utf8mb4_roman_ci = 239,
+    MYSQL_utf8mb4_persian_ci = 240,
+    MYSQL_utf8mb4_esperanto_ci = 241,
+    MYSQL_utf8mb4_hungarian_ci = 242,
+    MYSQL_utf8mb4_sinhala_ci = 243,
+    MYSQL_utf8mb4_german2_ci = 244,
+    MYSQL_utf8mb4_croatian_ci = 245,
+    MYSQL_utf8mb4_unicode_520_ci = 246,
+    MYSQL_utf8mb4_vietnamese_ci = 247,
+};
+
+const char* MysqlFieldTypeToString(MysqlFieldType);
+const char* MysqlRspTypeToString(MysqlRspType);
+
+class MysqlReply {
+public:
+    // Mysql Auth package
+    class Auth : private CheckParsed {
+    public:
+        Auth();
+        uint8_t protocol() const;
+        butil::StringPiece version() const;
+        uint32_t thread_id() const;
+        butil::StringPiece salt() const;
+        uint16_t capability() const;
+        uint8_t language() const;
+        uint16_t status() const;
+        uint16_t extended_capability() const;
+        uint8_t auth_plugin_length() const;
+        butil::StringPiece salt2() const;
+        butil::StringPiece auth_plugin() const;
+
+    private:
+        bool parse(butil::IOBuf& buf, butil::Arena* arena);
+
+        DISALLOW_COPY_AND_ASSIGN(Auth);
+        friend class MysqlReply;
+
+        uint8_t _protocol;
+        butil::StringPiece _version;
+        uint32_t _thread_id;
+        butil::StringPiece _salt;
+        uint16_t _capability;
+        uint8_t _language;
+        uint16_t _status;
+        uint16_t _extended_capability;
+        uint8_t _auth_plugin_length;
+        butil::StringPiece _salt2;
+        butil::StringPiece _auth_plugin;
+    };
+    // Mysql Ok package
+    class Ok : private CheckParsed {
+    public:
+        Ok();
+        uint64_t affect_row() const;
+        uint64_t index() const;
+        uint16_t status() const;
+        uint16_t warning() const;
+        butil::StringPiece msg() const;
+
+    private:
+        bool parse(butil::IOBuf& buf, butil::Arena* arena);
+
+        DISALLOW_COPY_AND_ASSIGN(Ok);
+        friend class MysqlReply;
+
+        uint64_t _affect_row;
+        uint64_t _index;
+        uint16_t _status;
+        uint16_t _warning;
+        butil::StringPiece _msg;
+    };
+    // Mysql Error package
+    class Error : private CheckParsed {
+    public:
+        Error();
+        uint16_t errcode() const;
+        butil::StringPiece status() const;
+        butil::StringPiece msg() const;
+
+    private:
+        bool parse(butil::IOBuf& buf, butil::Arena* arena);
+
+        DISALLOW_COPY_AND_ASSIGN(Error);
+        friend class MysqlReply;
+
+        uint16_t _errcode;
+        butil::StringPiece _status;
+        butil::StringPiece _msg;
+    };
+    // Mysql Eof package
+    class Eof : private CheckParsed {
+    public:
+        Eof();
+        uint16_t warning() const;
+        uint16_t status() const;
+
+    private:
+        bool parse(butil::IOBuf& buf);
+        bool isEof(const butil::IOBuf& buf);
+
+        DISALLOW_COPY_AND_ASSIGN(Eof);
+        friend class MysqlReply;
+
+        uint16_t _warning;
+        uint16_t _status;
+    };
+    // Mysql Column
+    class Column : private CheckParsed {
+    public:
+        Column();
+        butil::StringPiece catalog() const;
+        butil::StringPiece database() const;
+        butil::StringPiece table() const;
+        butil::StringPiece origin_table() const;
+        butil::StringPiece name() const;
+        butil::StringPiece origin_name() const;
+        MysqlCollation collation() const;
+        uint32_t length() const;
+        MysqlFieldType type() const;
+        MysqlFieldFlag flag() const;
+        uint8_t decimal() const;
+
+    private:
+        bool parse(butil::IOBuf& buf, butil::Arena* arena);
+
+        DISALLOW_COPY_AND_ASSIGN(Column);
+        friend class MysqlReply;
+
+        butil::StringPiece _catalog;
+        butil::StringPiece _database;
+        butil::StringPiece _table;
+        butil::StringPiece _origin_table;
+        butil::StringPiece _name;
+        butil::StringPiece _origin_name;
+        MysqlCollation _collation;
+        uint32_t _length;
+        MysqlFieldType _type;
+        MysqlFieldFlag _flag;
+        uint8_t _decimal;
+    };
+    // Mysql Field
+    class Field : private CheckParsed {
+    public:
+        Field();
+        int8_t stiny() const;
+        uint8_t tiny() const;
+        int16_t ssmall() const;
+        uint16_t small() const;
+        int32_t sinteger() const;
+        uint32_t integer() const;
+        int64_t sbigint() const;
+        uint64_t bigint() const;
+        float float32() const;
+        double float64() const;
+        butil::StringPiece string() const;
+
+        bool is_stiny() const;
+        bool is_tiny() const;
+        bool is_ssmall() const;
+        bool is_small() const;
+        bool is_sinteger() const;
+        bool is_integer() const;
+        bool is_sbigint() const;
+        bool is_bigint() const;
+        bool is_float32() const;
+        bool is_float64() const;
+        bool is_string() const;
+        bool is_nil() const;
+
+    private:
+        bool parse(butil::IOBuf& buf, const MysqlReply::Column* column, butil::Arena* arena);
+
+        DISALLOW_COPY_AND_ASSIGN(Field);
+        friend class MysqlReply;
+
+        union {
+            int8_t stiny;
+            uint8_t tiny;
+            int16_t ssmall;
+            uint16_t small;
+            int32_t sinteger;
+            uint32_t integer;
+            int64_t sbigint;
+            uint64_t bigint;
+            float float32;
+            double float64;
+            butil::StringPiece str;
+        } _data = {.str = NULL};
+        MysqlFieldType _type;
+        bool _is_unsigned;
+    };
+    // Mysql Row
+    class Row : private CheckParsed {
+    public:
+        Row();
+        uint64_t field_number() const;
+        const Field& field(const uint64_t index) const;
+
+    private:
+        bool parseText(butil::IOBuf& buf);
+
+        DISALLOW_COPY_AND_ASSIGN(Row);
+        friend class MysqlReply;
+
+        Field* _fields;
+        uint64_t _field_number;
+        Row* _next;
+    };
+
+public:
+    MysqlReply();
+    bool ConsumePartialIOBuf(butil::IOBuf& buf,
+                             butil::Arena* arena,
+                             const bool is_auth,
+                             bool* is_multi);
+    void Swap(MysqlReply& other);
+    void Print(std::ostream& os) const;
+    // response type
+    MysqlRspType type() const;
+    // get auth
+    const Auth* auth() const;
+    const Ok* ok() const;
+    const Error* error() const;
+    const Eof* eof() const;
+    // get column number
+    uint64_t column_number() const;
+    // get one column
+    const Column* column(const uint64_t index) const;
+    // get row number
+    uint64_t row_number() const;
+    // get one row
+    const Row* next() const;
+    bool is_auth() const;
+    bool is_ok() const;
+    bool is_error() const;
+    bool is_eof() const;
+    bool is_resultset() const;
+
+private:
+    // Mysql result set header
+    struct ResultSetHeader : private CheckParsed {
+        ResultSetHeader() : _column_number(0), _extra_msg(0) {}
+        bool parse(butil::IOBuf& buf);
+        uint64_t _column_number;
+        uint64_t _extra_msg;
+
+    private:
+        DISALLOW_COPY_AND_ASSIGN(ResultSetHeader);
+    };
+    // Mysql result set
+    struct ResultSet {
+        ResultSet() : _columns(NULL), _row_number(0) {
+            _first = _last = &_dummy;
+            _cur = _first;
+        }
+        ResultSetHeader _header;
+        Column* _columns;
+        Eof _eof1;
+        // row list
+        Row* _first;
+        Row* _cur;
+        Row* _last;
+        // row list end
+        uint64_t _row_number;
+        Eof _eof2;
+
+    private:
+        DISALLOW_COPY_AND_ASSIGN(ResultSet);
+        Row _dummy;
+    };
+    // member values
+    MysqlRspType _type;
+    union {
+        const Auth* auth;
+        union {
+            const ResultSet* const_var;
+            // build full result set, we may call ConsumePartialIOBuf many times
+            ResultSet* var;
+        } result_set;
+        const Ok* ok;
+        const Error* error;
+        const Eof* eof;
+        uint64_t padding;  // For swapping, must cover all bytes.
+    } _data;
+
+    DISALLOW_COPY_AND_ASSIGN(MysqlReply);
+};
+
+// mysql reply
+inline MysqlReply::MysqlReply() {
+    _type = MYSQL_RSP_UNKNOWN;
+    _data.padding = 0;
+}
+inline void MysqlReply::Swap(MysqlReply& other) {
+    std::swap(_type, other._type);
+    std::swap(_data.padding, other._data.padding);
+}
+inline std::ostream& operator<<(std::ostream& os, const MysqlReply& r) {
+    r.Print(os);
+    return os;
+}
+inline MysqlRspType MysqlReply::type() const {
+    return _type;
+}
+inline const MysqlReply::Auth* MysqlReply::auth() const {
+    if (is_auth()) {
+        return _data.auth;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an auth";
+    return NULL;
+}
+inline const MysqlReply::Ok* MysqlReply::ok() const {
+    if (is_ok()) {
+        return _data.ok;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an ok";
+    return NULL;
+}
+inline const MysqlReply::Error* MysqlReply::error() const {
+    if (is_error()) {
+        return _data.error;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an error";
+    return NULL;
+}
+inline const MysqlReply::Eof* MysqlReply::eof() const {
+    if (is_eof()) {
+        return _data.eof;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an eof";
+    return NULL;
+}
+inline uint64_t MysqlReply::column_number() const {
+    if (is_resultset()) {
+        return _data.result_set.const_var->_header._column_number;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an resultset";
+    return 0;
+}
+inline const MysqlReply::Column* MysqlReply::column(const uint64_t index) const {
+    if (is_resultset()) {
+        if (index > _data.result_set.const_var->_header._column_number) {
+            LOG(ERROR) << "wrong index, must between [0, "
+                       << _data.result_set.const_var->_header._column_number << ")";
+            return NULL;
+        }
+        return _data.result_set.const_var->_columns + index;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an resultset";
+    return NULL;
+}
+inline uint64_t MysqlReply::row_number() const {
+    if (is_resultset()) {
+        return _data.result_set.const_var->_row_number;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an resultset";
+    return 0;
+}
+inline const MysqlReply::Row* MysqlReply::next() const {
+    if (is_resultset()) {
+        if (_data.result_set.var->_cur == _data.result_set.var->_last->_next) {
+            _data.result_set.var->_cur = _data.result_set.var->_first;
+        }
+        _data.result_set.var->_cur = _data.result_set.var->_cur->_next;
+        return _data.result_set.var->_cur;
+    }
+    CHECK(false) << "The reply is " << MysqlRspTypeToString(_type) << ", not an resultset";
+    return NULL;
+}
+inline bool MysqlReply::is_auth() const {
+    return _type == MYSQL_RSP_AUTH;
+}
+inline bool MysqlReply::is_ok() const {
+    return _type == MYSQL_RSP_OK;
+}
+inline bool MysqlReply::is_error() const {
+    return _type == MYSQL_RSP_ERROR;
+}
+inline bool MysqlReply::is_eof() const {
+    return _type == MYSQL_RSP_EOF;
+}
+inline bool MysqlReply::is_resultset() const {
+    return _type == MYSQL_RSP_RESULTSET;
+}
+// mysql auth
+inline MysqlReply::Auth::Auth()
+    : _protocol(0),
+      _thread_id(0),
+      _capability(0),
+      _language(0),
+      _status(0),
+      _extended_capability(0),
+      _auth_plugin_length(0) {}
+inline uint8_t MysqlReply::Auth::protocol() const {
+    return _protocol;
+}
+inline butil::StringPiece MysqlReply::Auth::version() const {
+    return _version;
+}
+inline uint32_t MysqlReply::Auth::thread_id() const {
+    return _thread_id;
+}
+inline butil::StringPiece MysqlReply::Auth::salt() const {
+    return _salt;
+}
+inline uint16_t MysqlReply::Auth::capability() const {
+    return _capability;
+}
+inline uint8_t MysqlReply::Auth::language() const {
+    return _language;
+}
+inline uint16_t MysqlReply::Auth::status() const {
+    return _status;
+}
+inline uint16_t MysqlReply::Auth::extended_capability() const {
+    return _extended_capability;
+}
+inline uint8_t MysqlReply::Auth::auth_plugin_length() const {
+    return _auth_plugin_length;
+}
+inline butil::StringPiece MysqlReply::Auth::salt2() const {
+    return _salt2;
+}
+inline butil::StringPiece MysqlReply::Auth::auth_plugin() const {
+    return _auth_plugin;
+}
+// mysql reply ok
+inline MysqlReply::Ok::Ok() : _affect_row(0), _index(0), _status(0), _warning(0) {}
+inline uint64_t MysqlReply::Ok::affect_row() const {
+    return _affect_row;
+}
+inline uint64_t MysqlReply::Ok::index() const {
+    return _index;
+}
+inline uint16_t MysqlReply::Ok::status() const {
+    return _status;
+}
+inline uint16_t MysqlReply::Ok::warning() const {
+    return _warning;
+}
+inline butil::StringPiece MysqlReply::Ok::msg() const {
+    return _msg;
+}
+// mysql reply error
+inline MysqlReply::Error::Error() : _errcode(0) {}
+inline uint16_t MysqlReply::Error::errcode() const {
+    return _errcode;
+}
+inline butil::StringPiece MysqlReply::Error::status() const {
+    return _status;
+}
+inline butil::StringPiece MysqlReply::Error::msg() const {
+    return _msg;
+}
+// mysql reply eof
+inline MysqlReply::Eof::Eof() : _warning(0), _status(0) {}
+inline uint16_t MysqlReply::Eof::warning() const {
+    return _warning;
+}
+inline uint16_t MysqlReply::Eof::status() const {
+    return _status;
+}
+// mysql reply column
+inline MysqlReply::Column::Column() : _length(0), _decimal(0) {}
+inline butil::StringPiece MysqlReply::Column::catalog() const {
+    return _catalog;
+}
+inline butil::StringPiece MysqlReply::Column::database() const {
+    return _database;
+}
+inline butil::StringPiece MysqlReply::Column::table() const {
+    return _table;
+}
+inline butil::StringPiece MysqlReply::Column::origin_table() const {
+    return _origin_table;
+}
+inline butil::StringPiece MysqlReply::Column::name() const {
+    return _name;
+}
+inline butil::StringPiece MysqlReply::Column::origin_name() const {
+    return _origin_name;
+}
+inline MysqlCollation MysqlReply::Column::collation() const {
+    return _collation;
+}
+inline uint32_t MysqlReply::Column::length() const {
+    return _length;
+}
+inline MysqlFieldType MysqlReply::Column::type() const {
+    return _type;
+}
+inline MysqlFieldFlag MysqlReply::Column::flag() const {
+    return _flag;
+}
+inline uint8_t MysqlReply::Column::decimal() const {
+    return _decimal;
+}
+// mysql reply row
+inline MysqlReply::Row::Row() : _fields(NULL), _field_number(0), _next(NULL) {}
+inline uint64_t MysqlReply::Row::field_number() const {
+    return _field_number;
+}
+inline const MysqlReply::Field& MysqlReply::Row::field(const uint64_t index) const {
+    if (index > _field_number) {
+        LOG(ERROR) << "wrong index, must between [0, " << _field_number << ")";
+        static Field field_nil;
+        return field_nil;
+    }
+    return _fields[index];
+}
+// mysql reply field
+inline MysqlReply::Field::Field() : _type(MYSQL_FIELD_TYPE_NULL), _is_unsigned(false) {}
+inline int8_t MysqlReply::Field::stiny() const {
+    if (is_stiny()) {
+        return _data.stiny;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an stiny";
+    return 0;
+}
+inline uint8_t MysqlReply::Field::tiny() const {
+    if (is_tiny()) {
+        return _data.tiny;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an tiny";
+    return 0;
+}
+inline int16_t MysqlReply::Field::ssmall() const {
+    if (is_ssmall()) {
+        return _data.ssmall;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an ssmall";
+    return 0;
+}
+inline uint16_t MysqlReply::Field::small() const {
+    if (is_small()) {
+        return _data.small;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an small";
+    return 0;
+}
+inline int32_t MysqlReply::Field::sinteger() const {
+    if (is_sinteger()) {
+        return _data.sinteger;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an sinteger";
+    return 0;
+}
+inline uint32_t MysqlReply::Field::integer() const {
+    if (is_integer()) {
+        return _data.integer;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an integer";
+    return 0;
+}
+inline int64_t MysqlReply::Field::sbigint() const {
+    if (is_sbigint()) {
+        return _data.sbigint;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an sbigint";
+    return 0;
+}
+inline uint64_t MysqlReply::Field::bigint() const {
+    if (is_bigint()) {
+        return _data.bigint;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an bigint";
+    return 0;
+}
+inline float MysqlReply::Field::float32() const {
+    if (is_float32()) {
+        return _data.float32;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an float32";
+    return 0;
+}
+inline double MysqlReply::Field::float64() const {
+    if (is_float64()) {
+        return _data.float64;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an float64";
+    return 0;
+}
+inline butil::StringPiece MysqlReply::Field::string() const {
+    if (is_string()) {
+        return _data.str;
+    }
+    CHECK(false) << "The reply is " << MysqlFieldTypeToString(_type) << ", not an string";
+    return butil::StringPiece();
+}
+inline bool MysqlReply::Field::is_stiny() const {
+    return _type == MYSQL_FIELD_TYPE_TINY && !_is_unsigned;
+}
+inline bool MysqlReply::Field::is_tiny() const {
+    return _type == MYSQL_FIELD_TYPE_TINY && _is_unsigned;
+}
+inline bool MysqlReply::Field::is_ssmall() const {
+    return (_type == MYSQL_FIELD_TYPE_SHORT || _type == MYSQL_FIELD_TYPE_YEAR) && !_is_unsigned;
+}
+inline bool MysqlReply::Field::is_small() const {
+    return (_type == MYSQL_FIELD_TYPE_SHORT || _type == MYSQL_FIELD_TYPE_YEAR) && _is_unsigned;
+}
+inline bool MysqlReply::Field::is_sinteger() const {
+    return (_type == MYSQL_FIELD_TYPE_INT24 || _type == MYSQL_FIELD_TYPE_LONG) && !_is_unsigned;
+}
+inline bool MysqlReply::Field::is_integer() const {
+    return (_type == MYSQL_FIELD_TYPE_INT24 || _type == MYSQL_FIELD_TYPE_LONG) && _is_unsigned;
+}
+inline bool MysqlReply::Field::is_sbigint() const {
+    return _type == MYSQL_FIELD_TYPE_LONGLONG && !_is_unsigned;
+}
+inline bool MysqlReply::Field::is_bigint() const {
+    return _type == MYSQL_FIELD_TYPE_LONGLONG && _is_unsigned;
+}
+inline bool MysqlReply::Field::is_float32() const {
+    return _type == MYSQL_FIELD_TYPE_FLOAT;
+}
+inline bool MysqlReply::Field::is_float64() const {
+    return _type == MYSQL_FIELD_TYPE_DOUBLE;
+}
+inline bool MysqlReply::Field::is_string() const {
+    return _type == MYSQL_FIELD_TYPE_DECIMAL || _type == MYSQL_FIELD_TYPE_NEWDECIMAL ||
+        _type == MYSQL_FIELD_TYPE_VARCHAR || _type == MYSQL_FIELD_TYPE_BIT ||
+        _type == MYSQL_FIELD_TYPE_ENUM || _type == MYSQL_FIELD_TYPE_SET ||
+        _type == MYSQL_FIELD_TYPE_TINY_BLOB || _type == MYSQL_FIELD_TYPE_MEDIUM_BLOB ||
+        _type == MYSQL_FIELD_TYPE_LONG_BLOB || _type == MYSQL_FIELD_TYPE_BLOB ||
+        _type == MYSQL_FIELD_TYPE_VAR_STRING || _type == MYSQL_FIELD_TYPE_STRING ||
+        _type == MYSQL_FIELD_TYPE_GEOMETRY || _type == MYSQL_FIELD_TYPE_JSON ||
+        _type == MYSQL_FIELD_TYPE_TIME || _type == MYSQL_FIELD_TYPE_DATE ||
+        _type == MYSQL_FIELD_TYPE_NEWDATE || _type == MYSQL_FIELD_TYPE_TIMESTAMP ||
+        _type == MYSQL_FIELD_TYPE_DATETIME;
+}
+inline bool MysqlReply::Field::is_nil() const {
+    return _type == MYSQL_FIELD_TYPE_NULL;
+}
+// little endian order to host order
+inline uint16_t mysql_uint2korr(const uint8_t* A) {
+    return (uint16_t)(((uint16_t)(A[0])) + ((uint16_t)(A[1]) << 8));
+}
+inline uint32_t mysql_uint3korr(const uint8_t* A) {
+    return (uint32_t)(((uint32_t)(A[0])) + (((uint32_t)(A[1])) << 8) + (((uint32_t)(A[2])) << 16));
+}
+inline uint32_t mysql_uint4korr(const uint8_t* A) {
+    return (uint32_t)(((uint32_t)(A[0])) + (((uint32_t)(A[1])) << 8) + (((uint32_t)(A[2])) << 16) +
+                      (((uint32_t)(A[3])) << 24));
+}
+inline uint64_t mysql_uint8korr(const uint8_t* A) {
+    return (uint64_t)(((uint64_t)(A[0])) + (((uint64_t)(A[1])) << 8) + (((uint64_t)(A[2])) << 16) +
+                      (((uint64_t)(A[3])) << 24) + (((uint64_t)(A[4])) << 32) +
+                      (((uint64_t)(A[5])) << 40) + (((uint64_t)(A[6])) << 48) +
+                      (((uint64_t)(A[7])) << 56));
+}
+
+}  // namespace brpc
+
+#endif  // BRPC_MYSQL_UTIL_H

--- a/src/brpc/options.proto
+++ b/src/brpc/options.proto
@@ -47,6 +47,7 @@ enum ProtocolType {
     PROTOCOL_CDS_AGENT = 24;           // Client side only
     PROTOCOL_ESP = 25;                 // Client side only
     PROTOCOL_H2 = 26;
+    PROTOCOL_MYSQL = 27;               // Client side only
 }
 
 enum CompressType {

--- a/src/brpc/policy/mysql_auth_hash.cpp
+++ b/src/brpc/policy/mysql_auth_hash.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2.0, as
+ * published by the Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including
+ * but not limited to OpenSSL) that is licensed under separate terms,
+ * as designated in a particular file or component or in included license
+ * documentation.  The authors of MySQL hereby grant you an
+ * additional permission to link the program and your derivative works
+ * with the separately licensed software that they have included with
+ * MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file,
+ * which is part of MySQL Connector/C++, is also subject to the
+ * Universal FOSS Exception, version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License, version 2.0, for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#include "mysql_auth_hash.h"
+#include <stdint.h>
+#include <stdexcept>
+#include <string.h>         // memset
+#include "butil/logging.h"  // LOG()
+
+// Avoid warnings from protobuf
+#if defined __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#elif defined _MSC_VER
+#pragma warning(push)
+#endif
+
+#include <openssl/sha.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#elif defined _MSC_VER
+#pragma warning(pop)
+#endif
+
+
+#define PVERSION41_CHAR '*'
+#define SCRAMBLE_LENGTH 20
+#define SHA1_HASH_SIZE 20
+#define SHA256_HASH_SIZE 32
+
+typedef unsigned char byte;
+typedef size_t length_t;
+
+class SHA {
+    SHA_CTX m_sha;
+
+    void init() {
+        SHA1_Init(&m_sha);
+    }
+
+public:
+    enum { DIGEST_SIZE = SHA1_HASH_SIZE };  // in Bytes
+
+    SHA() {
+        init();
+    }
+
+    void Update(byte* data, length_t length) {
+        SHA1_Update(&m_sha,
+                    data,
+#ifdef WITH_SSL_WOLFSSL
+                    (unsigned long)
+#endif
+                        length);
+    }
+
+    void Final(byte* hash) {
+        SHA1_Final(hash, &m_sha);
+        init();
+    }
+
+    size_t getDigestSize() const {
+        return SHA1_HASH_SIZE;
+    }
+};
+
+class SHA256 {
+    SHA256_CTX m_sha;
+
+    void init() {
+        SHA256_Init(&m_sha);
+    }
+
+public:
+    enum { DIGEST_SIZE = SHA256_HASH_SIZE };  // in Bytes
+
+    SHA256() {
+        init();
+    }
+
+    void Update(byte* data, length_t length) {
+        SHA256_Update(&m_sha, data, length);
+    }
+
+    void Final(byte* hash) {
+        SHA256_Final(hash, &m_sha);
+        init();
+    }
+
+    size_t getDigestSize() const {
+        return SHA256_HASH_SIZE;
+    }
+};
+
+
+static void my_crypt(uint8_t* to, const uint8_t* s1, const uint8_t* s2, size_t len) {
+    const uint8_t* s1_end = s1 + len;
+
+    while (s1 < s1_end)
+        *to++ = *s1++ ^ *s2++;
+}
+
+
+template <class SHA_Crypt>
+static std::string scramble(const std::string& scramble_data, const std::string& password) {
+    SHA_Crypt sha;
+
+    if (scramble_data.length() != SCRAMBLE_LENGTH)
+        throw std::invalid_argument("Password scramble data is invalid");
+
+    byte hash_stage1[SHA_Crypt::DIGEST_SIZE];
+    byte hash_stage2[SHA_Crypt::DIGEST_SIZE];
+    byte result_buf[SHA_Crypt::DIGEST_SIZE + 1];
+
+    memset(result_buf, 0, sizeof(result_buf));
+
+    /* Two stage SHA1 hash of the pwd */
+    /* Stage 1: hash pwd */
+    sha.Update((byte*)password.data(), (length_t)password.length());
+    sha.Final(hash_stage1);
+
+    /* Stage 2 : hash first stage's output. */
+    sha.Update(hash_stage1, sha.getDigestSize());
+    sha.Final(hash_stage2);
+
+    /* create crypt string as sha1(message, hash_stage2) */;
+    /* MYSQL41 and SHA256_PASSWORD have different behaviors here! Bug? */
+    if (sha.getDigestSize() == SHA1_HASH_SIZE) {
+        sha.Update((byte*)scramble_data.data(), (length_t)scramble_data.length());
+        sha.Update(hash_stage2, sha.getDigestSize());
+    } else {
+        sha.Update(hash_stage2, sha.getDigestSize());
+        sha.Update((byte*)scramble_data.data(), (length_t)scramble_data.length());
+    }
+    sha.Final(result_buf);
+    result_buf[sha.getDigestSize()] = '\0';
+
+    my_crypt(result_buf, result_buf, hash_stage1, sha.getDigestSize());
+
+    return std::string((char*)result_buf, sha.getDigestSize());
+}
+
+static char* octet2hex(char* to, const char* str, size_t len) {
+    const char* _dig_vec_upper = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    const char* str_end = str + len;
+    for (; str != str_end; ++str) {
+        *to++ = _dig_vec_upper[((uint8_t)*str) >> 4];
+        *to++ = _dig_vec_upper[((uint8_t)*str) & 0x0F];
+    }
+    *to = '\0';
+    return to;
+}
+
+// MYSQL41 specific
+
+std::string brpc::policy::mysql_build_mysql41_authentication_response(const std::string& salt_data,
+                                                                      const std::string& password) {
+    std::string data;
+    std::string password_hash;
+    if (password.length()) {
+        password_hash = scramble<class SHA>(salt_data, password);
+    }
+    data.append(password_hash);  // pass
+
+    return data;
+}
+
+// SHA256_MEMORY specific
+
+static std::string get_password_from_salt_sha256(const std::string& hash_stage2) {
+    std::string result(2 * SHA256_HASH_SIZE + 1, '\0');
+
+    if (hash_stage2.length() != SHA256_HASH_SIZE)
+        throw std::invalid_argument("Wrong size of binary hash password");
+
+    octet2hex(&result[0], &hash_stage2[0], SHA256_HASH_SIZE);
+
+    return result;
+}
+
+std::string brpc::policy::mysql_build_sha256_authentication_response(const std::string& salt_data,
+                                                                     const std::string& user,
+                                                                     const std::string& password,
+                                                                     const std::string& schema) {
+    std::string password_hash;
+    std::string data;
+
+    password_hash = scramble<class SHA256>(salt_data, password);
+    password_hash = get_password_from_salt_sha256(password_hash);
+    // REMOVE ending \0
+    password_hash.pop_back();
+
+    data.append(schema).push_back('\0');  // authz
+    data.append(user).push_back('\0');    // authc
+    data.append(password_hash);           // pass
+
+    return data;
+}

--- a/src/brpc/policy/mysql_auth_hash.h
+++ b/src/brpc/policy/mysql_auth_hash.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2.0, as
+ * published by the Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including
+ * but not limited to OpenSSL) that is licensed under separate terms,
+ * as designated in a particular file or component or in included license
+ * documentation.  The authors of MySQL hereby grant you an
+ * additional permission to link the program and your derivative works
+ * with the separately licensed software that they have included with
+ * MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file,
+ * which is part of MySQL Connector/C++, is also subject to the
+ * Universal FOSS Exception, version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License, version 2.0, for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef BRPC_POLICY_MYSQL_AUTH_HASH_H
+#define BRPC_POLICY_MYSQL_AUTH_HASH_H
+
+// #include <mysql/cdk/config.h>
+#include <string>
+
+namespace brpc {
+namespace policy {
+
+std::string mysql_build_mysql41_authentication_response(const std::string& salt_data,
+                                                        const std::string& password);
+
+std::string mysql_build_sha256_authentication_response(const std::string& salt_data,
+                                                       const std::string& user,
+                                                       const std::string& password,
+                                                       const std::string& schema);
+}  // namespace policy
+}  // namespace brpc
+
+#endif

--- a/src/brpc/policy/mysql_authenticator.cpp
+++ b/src/brpc/policy/mysql_authenticator.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): Yang,Liming <yangliming01@baidu.com>
+
+#include "brpc/policy/mysql_authenticator.h"
+#include "brpc/policy/mysql_auth_hash.h"
+#include "brpc/mysql_reply.h"
+#include "butil/base64.h"
+#include "butil/iobuf.h"
+#include "butil/logging.h"  // LOG()
+#include "butil/sys_byteorder.h"
+
+namespace brpc {
+namespace policy {
+
+namespace {
+const butil::StringPiece mysql_native_password("mysql_native_password");
+std::string PackEncodeLength(const uint64_t value) {
+    std::stringstream ss;
+    if (value <= 250) {
+        ss.put((char)value);
+    } else if (value <= 0xffff) {
+        ss.put((char)0xfc).put((char)value).put((char)(value >> 8));
+    } else if (value <= 0xffffff) {
+        ss.put((char)0xfd).put((char)value).put((char)(value >> 8)).put((char)(value >> 16));
+    } else {
+        ss.put((char)0xfd)
+            .put((char)value)
+            .put((char)(value >> 8))
+            .put((char)(value >> 16))
+            .put((char)(value >> 24))
+            .put((char)(value >> 32))
+            .put((char)(value >> 40))
+            .put((char)(value >> 48))
+            .put((char)(value >> 56));
+    }
+    return ss.str();
+}
+};  // namespace
+
+int MysqlPackAuthenticator(const MysqlReply::Auth* auth,
+                           const std::string* raw,
+                           std::string* auth_str) {
+    const size_t pos1 = raw->find(':', 0);
+    const size_t pos2 = raw->find(':', pos1 + 1);
+    const size_t pos3 = raw->find(':', pos2 + 1);
+    const std::string user = std::string(*raw, 0, pos1);
+    const std::string passwd = std::string(*raw, pos1 + 1, pos2 - pos1 - 1);
+    const std::string schema = std::string(*raw, pos2 + 1, pos3 - pos2 - 1);
+    const MysqlCollation collation = (MysqlCollation)atoi(std::string(*raw, pos3 + 1).c_str());
+
+    const uint16_t capability =
+        butil::ByteSwapToLE16((schema == "" ? 0x8285 : 0x828d) & auth->capability());
+    const uint16_t extended_capability =
+        butil::ByteSwapToLE16(0x000b & auth->extended_capability());
+    const uint32_t max_package_length = butil::ByteSwapToLE32(16777216UL);
+    butil::IOBuf salt;
+    salt.append(auth->salt().data(), auth->salt().size());
+    salt.append(auth->salt2().data(), auth->salt2().size());
+    if (auth->auth_plugin() == mysql_native_password) {
+        salt = mysql_build_mysql41_authentication_response(salt.to_string(), passwd);
+    } else {
+        LOG(ERROR) << "no support auth plugin " << auth->auth_plugin();
+        return 1;
+    }
+
+    butil::IOBuf payload;
+    payload.append(&capability, 2);
+    payload.append(&extended_capability, 2);
+    payload.append(&max_package_length, 4);
+    payload.append(&collation, 1);
+    const std::string stuff(23, '\0');
+    payload.append(stuff);
+    payload.append(user);
+    payload.push_back('\0');
+    payload.append(PackEncodeLength(salt.size()));
+    payload.append(salt);
+    if (schema != "") {
+        payload.append(schema);
+        payload.push_back('\0');
+    }
+    if (auth->auth_plugin() == mysql_native_password) {
+        payload.append(mysql_native_password.data(), mysql_native_password.size());
+        payload.push_back('\0');
+    }
+    butil::IOBuf message;
+    const uint32_t payload_size = butil::ByteSwapToLE32(payload.size());
+    // header
+    message.append(&payload_size, 3);
+    message.push_back(0x01);
+    // payload
+    message.append(payload);
+    *auth_str = message.to_string();
+    return 0;
+}
+
+int MysqlAuthenticator::GenerateCredential(std::string* auth_str) const {
+    // do nothing
+    return 0;
+}
+
+}  // namespace policy
+}  // namespace brpc

--- a/src/brpc/policy/mysql_authenticator.h
+++ b/src/brpc/policy/mysql_authenticator.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): Yang,Liming <yangliming01@baidu.com>
+
+#ifndef BRPC_POLICY_MYSQL_AUTHENTICATOR_H
+#define BRPC_POLICY_MYSQL_AUTHENTICATOR_H
+
+#include "butil/iobuf.h"
+#include "brpc/authenticator.h"
+#include "brpc/mysql_reply.h"
+
+namespace brpc {
+namespace policy {
+// pack mysql authentication_data
+int MysqlPackAuthenticator(const MysqlReply::Auth* auth,
+                           const std::string* user,
+                           std::string* auth_str);
+// Request to mysql for authentication.
+class MysqlAuthenticator : public Authenticator {
+public:
+    MysqlAuthenticator(const std::string& user,
+                       const std::string& passwd,
+                       const std::string& schema = "",
+                       const MysqlCollation collation = MYSQL_utf8_general_ci)
+        : _user(user), _passwd(passwd), _schema(schema), _collation(collation) {}
+
+    int GenerateCredential(std::string* auth_str) const;
+
+    int VerifyCredential(const std::string&, const butil::EndPoint&, brpc::AuthContext*) const {
+        return 0;
+    }
+
+    const std::string& user() const;
+    const std::string& passwd() const;
+    const std::string& schema() const;
+    MysqlCollation collation() const;
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(MysqlAuthenticator);
+
+    const std::string _user;
+    const std::string _passwd;
+    const std::string _schema;
+    const MysqlCollation _collation;
+};
+
+inline const std::string& MysqlAuthenticator::user() const {
+    return _user;
+}
+
+inline const std::string& MysqlAuthenticator::schema() const {
+    return _schema;
+}
+
+inline const std::string& MysqlAuthenticator::passwd() const {
+    return _passwd;
+}
+
+inline MysqlCollation MysqlAuthenticator::collation() const {
+    return _collation;
+}
+
+}  // namespace policy
+}  // namespace brpc
+
+#endif  // BRPC_POLICY_COUCHBASE_AUTHENTICATOR_H

--- a/src/brpc/policy/mysql_protocol.cpp
+++ b/src/brpc/policy/mysql_protocol.cpp
@@ -1,0 +1,237 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Yang,Liming (yangliming01@baidu.com)
+
+#include <google/protobuf/descriptor.h>  // MethodDescriptor
+#include <google/protobuf/message.h>     // Message
+#include <gflags/gflags.h>
+#include <sstream>
+#include "butil/logging.h"  // LOG()
+#include "butil/time.h"
+#include "butil/iobuf.h"  // butil::IOBuf
+#include "butil/sys_byteorder.h"
+#include "brpc/controller.h"  // Controller
+#include "brpc/details/controller_private_accessor.h"
+#include "brpc/socket.h"  // Socket
+#include "brpc/server.h"  // Server
+#include "brpc/details/server_private_accessor.h"
+#include "brpc/span.h"
+#include "brpc/mysql.h"
+#include "brpc/mysql_reply.h"
+#include "brpc/policy/mysql_protocol.h"
+#include "brpc/policy/most_common_message.h"
+#include "brpc/policy/mysql_authenticator.h"
+
+namespace brpc {
+
+DECLARE_bool(enable_rpcz);
+
+namespace policy {
+
+DEFINE_bool(mysql_verbose, false, "[DEBUG] Print EVERY mysql request/response");
+
+
+MysqlAuthenticator* global_mysql_authenticator();
+
+struct InputResponse : public InputMessageBase {
+    bthread_id_t id_wait;
+    MysqlResponse response;
+
+    // @InputMessageBase
+    void DestroyImpl() {
+        delete this;
+    }
+};
+
+// "Message" = "Response" as we only implement the client for mysql.
+ParseResult ParseMysqlMessage(butil::IOBuf* source,
+                              Socket* socket,
+                              bool /*read_eof*/,
+                              const void* /*arg*/) {
+    if (source->empty()) {
+        return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);
+    }
+
+    PipelinedInfo pi;
+    if (!socket->PopPipelinedInfo(&pi)) {
+        LOG(WARNING) << "No corresponding PipelinedInfo in socket";
+        return MakeParseError(PARSE_ERROR_TRY_OTHERS);
+    }
+
+    do {
+        InputResponse* msg = static_cast<InputResponse*>(socket->parsing_context());
+        if (msg == NULL) {
+            msg = new InputResponse;
+            socket->reset_parsing_context(msg);
+        }
+
+        if (msg->response.ConsumePartialIOBuf(*source, pi.with_auth) == false) {
+            socket->GivebackPipelinedInfo(pi);
+            return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);
+        }
+        if (pi.with_auth) {
+            if (FLAGS_mysql_verbose) {
+                LOG(INFO) << "\n[MYSQL RESPONSE] " << msg->response;
+            }
+            const bthread_id_t cid = pi.id_wait;
+            Controller* cntl = NULL;
+            if (bthread_id_lock(cid, (void**)&cntl) != 0) {
+                LOG(ERROR) << "[MYSQL PARSE] fail to lock controller";
+                return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+            }
+            const AuthContext* ctx = cntl->auth_context();
+            if (ctx == NULL) {
+                LOG(ERROR) << "[MYSQL PARSE] auth context is null";
+                return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+            }
+            const MysqlReply& reply = msg->response.reply(0);
+            if (reply.is_auth()) {
+                std::string auth_str;
+                if (MysqlPackAuthenticator(reply.auth(), &ctx->user(), &auth_str) != 0) {
+                    bthread_id_unlock(cid);
+                    LOG(ERROR) << "[MYSQL PARSE] wrong pack authentication data";
+                    return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+                }
+                butil::IOBuf auth_resp;
+                auth_resp.append(auth_str);
+                auth_resp.cut_into_file_descriptor(socket->fd());
+            } else if (reply.is_ok()) {
+                butil::IOBuf raw_req;
+                raw_req.append(ctx->starter());
+                raw_req.cut_into_file_descriptor(socket->fd());
+                pi.with_auth = false;
+            } else if (reply.is_error()) {
+                bthread_id_unlock(cid);
+                LOG(ERROR) << reply;
+                return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+            } else {
+                bthread_id_unlock(cid);
+                LOG(ERROR) << "[MYSQL PARSE] wrong authentication step";
+                return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+            }
+
+            if (bthread_id_unlock(cid) != 0) {
+                LOG(ERROR) << "[MYSQL PARSE] fail to unlock controller";
+                return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+            }
+
+            DestroyingPtr<InputResponse> auth_msg =
+                static_cast<InputResponse*>(socket->release_parsing_context());
+            socket->GivebackPipelinedInfo(pi);
+            return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);
+        }
+
+        msg->id_wait = pi.id_wait;
+        socket->release_parsing_context();
+        return MakeMessage(msg);
+    } while (true);
+
+    return MakeParseError(PARSE_ERROR_ABSOLUTELY_WRONG);
+}
+
+void ProcessMysqlResponse(InputMessageBase* msg_base) {
+    const int64_t start_parse_us = butil::cpuwide_time_us();
+    DestroyingPtr<InputResponse> msg(static_cast<InputResponse*>(msg_base));
+
+    const bthread_id_t cid = msg->id_wait;
+    Controller* cntl = NULL;
+    const int rc = bthread_id_lock(cid, (void**)&cntl);
+    if (rc != 0) {
+        LOG_IF(ERROR, rc != EINVAL && rc != EPERM)
+            << "Fail to lock correlation_id=" << cid << ": " << berror(rc);
+        return;
+    }
+
+    ControllerPrivateAccessor accessor(cntl);
+    Span* span = accessor.span();
+    if (span) {
+        span->set_base_real_us(msg->base_real_us());
+        span->set_received_us(msg->received_us());
+        span->set_response_size(msg->response.ByteSize());
+        span->set_start_parse_us(start_parse_us);
+    }
+    const int saved_error = cntl->ErrorCode();
+    if (cntl->response() != NULL) {
+        if (cntl->response()->GetDescriptor() != MysqlResponse::descriptor()) {
+            cntl->SetFailed(ERESPONSE, "Must be MysqlResponse");
+        } else {
+            // We work around ParseFrom of pb which is just a placeholder.
+            ((MysqlResponse*)cntl->response())->Swap(&msg->response);
+            if (FLAGS_mysql_verbose) {
+                LOG(INFO) << "\n[MYSQL RESPONSE] " << *((MysqlResponse*)cntl->response());
+            }
+        }
+    }  // silently ignore the response.
+
+    // Unlocks correlation_id inside. Revert controller's
+    // error code if it version check of `cid' fails
+    msg.reset();  // optional, just release resourse ASAP
+    accessor.OnResponse(cid, saved_error);
+}
+
+void SerializeMysqlRequest(butil::IOBuf* buf,
+                           Controller* cntl,
+                           const google::protobuf::Message* request) {
+    if (request == NULL) {
+        return cntl->SetFailed(EREQUEST, "request is NULL");
+    }
+    if (request->GetDescriptor() != MysqlRequest::descriptor()) {
+        return cntl->SetFailed(EREQUEST, "The request is not a MysqlRequest");
+    }
+    const MysqlRequest* rr = (const MysqlRequest*)request;
+    // We work around SerializeTo of pb which is just a placeholder.
+    if (!rr->SerializeTo(buf)) {
+        return cntl->SetFailed(EREQUEST, "Fail to serialize MysqlRequest");
+    }
+    ControllerPrivateAccessor(cntl).set_pipelined_count(1);
+    if (FLAGS_mysql_verbose) {
+        LOG(INFO) << "\n[MYSQL REQUEST] " << *rr;
+    }
+}
+
+void PackMysqlRequest(butil::IOBuf* buf,
+                      SocketMessage**,
+                      uint64_t /*correlation_id*/,
+                      const google::protobuf::MethodDescriptor*,
+                      Controller* cntl,
+                      const butil::IOBuf& request,
+                      const Authenticator* auth) {
+    if (auth) {
+        const MysqlAuthenticator* my_auth(dynamic_cast<const MysqlAuthenticator*>(auth));
+        if (my_auth == NULL) {
+            LOG(ERROR) << "[MYSQL PACK] there is not MysqlAuthenticator";
+            return;
+        }
+        AuthContext* ctx = new AuthContext;
+        std::stringstream ss;
+        ss << my_auth->user() << ":" << my_auth->passwd() << ":" << my_auth->schema() << ":"
+           << (uint16_t)my_auth->collation();
+        ctx->set_user(ss.str());
+        ctx->set_starter(request.to_string());
+        ControllerPrivateAccessor(cntl).set_auth_context(ctx);
+        ControllerPrivateAccessor(cntl).add_with_auth();
+    } else {
+        buf->append(request);
+    }
+}
+
+const std::string& GetMysqlMethodName(const google::protobuf::MethodDescriptor*,
+                                      const Controller*) {
+    const static std::string MYSQL_SERVER_STR = "mysql-server";
+    return MYSQL_SERVER_STR;
+}
+
+}  // namespace policy
+}  // namespace brpc

--- a/src/brpc/policy/mysql_protocol.h
+++ b/src/brpc/policy/mysql_protocol.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Baidu, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Authors: Yang,Liming (yangliming01@baidu.com)
+
+#ifndef BRPC_POLICY_MYSQL_PROTOCOL_H
+#define BRPC_POLICY_MYSQL_PROTOCOL_H
+
+#include "brpc/protocol.h"
+
+
+namespace brpc {
+namespace policy {
+
+// Parse mysql response.
+ParseResult ParseMysqlMessage(butil::IOBuf* source, Socket* socket, bool read_eof, const void* arg);
+
+// Actions to a mysql response.
+void ProcessMysqlResponse(InputMessageBase* msg);
+
+// Serialize a mysql request.
+void SerializeMysqlRequest(butil::IOBuf* buf,
+                           Controller* cntl,
+                           const google::protobuf::Message* request);
+
+// Pack `request' to `method' into `buf'.
+void PackMysqlRequest(butil::IOBuf* buf,
+                      SocketMessage**,
+                      uint64_t correlation_id,
+                      const google::protobuf::MethodDescriptor* method,
+                      Controller* controller,
+                      const butil::IOBuf& request,
+                      const Authenticator* auth);
+
+const std::string& GetMysqlMethodName(const google::protobuf::MethodDescriptor*, const Controller*);
+
+}  // namespace policy
+}  // namespace brpc
+
+
+#endif  // BRPC_POLICY_MYSQL_PROTOCOL_H

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1523,7 +1523,7 @@ int Socket::Write(butil::IOBuf* data, const WriteOptions* options_in) {
     if (options_in) {
         opt = *options_in;
     }
-    if (data->empty()) {
+    if (data->empty() && opt.with_auth == false) {
         return SetError(opt.id_wait, EINVAL);
     }
     if (opt.pipelined_count > MAX_PIPELINED_COUNT) {

--- a/test/brpc_mysql_unittest.cpp
+++ b/test/brpc_mysql_unittest.cpp
@@ -1,0 +1,600 @@
+// Copyright (c) 2019 Baidu, Inc.
+// Date: Thu Jun 11 14:30:07 CST 2015
+
+
+#include <iostream>
+#include <sstream>
+#include "butil/time.h"
+#include <brpc/mysql.h>
+#include <brpc/channel.h>
+#include "butil/logging.h"  // LOG()
+#include "butil/strings/string_piece.h"
+#include <brpc/policy/mysql_authenticator.h>
+#include <gtest/gtest.h>
+
+namespace brpc {
+const std::string MYSQL_connection_type = "pooled";
+const int MYSQL_timeout_ms = 1000;
+const int MYSQL_connect_timeout_ms = 1000;
+
+const std::string MYSQL_host = "127.0.0.1";
+const std::string MYSQL_port = "3306";
+const std::string MYSQL_user = "yangliming01";
+const std::string MYSQL_password = "123456";
+const std::string MYSQL_schema = "test";
+int MYSQL_cnt = 0;
+}  // namespace brpc
+
+int main(int argc, char* argv[]) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+namespace {
+static pthread_once_t check_mysql_server_once = PTHREAD_ONCE_INIT;
+
+static void CheckMysqlServer() {
+    puts("Checking mysql-server...");
+    std::stringstream ss;
+    ss << "mysql"
+       << " -h" << brpc::MYSQL_host << " -P" << brpc::MYSQL_port << " -u" << brpc::MYSQL_user
+       << " -p" << brpc::MYSQL_password << " -D" << brpc::MYSQL_schema << " -e 'show databases'";
+    puts(ss.str().c_str());
+    if (system(ss.str().c_str()) != 0) {
+        std::stringstream ss;
+        ss << "please startup your mysql-server, then create \nschema:" << brpc::MYSQL_schema
+           << "\nuser:" << brpc::MYSQL_user << "\npassword:" << brpc::MYSQL_password;
+        puts(ss.str().c_str());
+        return;
+    }
+}
+
+class MysqlTest : public testing::Test {
+protected:
+    MysqlTest() {}
+    void SetUp() {
+        pthread_once(&check_mysql_server_once, CheckMysqlServer);
+    }
+    void TearDown() {}
+};
+
+TEST_F(MysqlTest, auth) {
+    // config auth
+    {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_MYSQL;
+        options.connection_type = brpc::MYSQL_connection_type;
+        options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+        options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+        options.auth = new brpc::policy::MysqlAuthenticator(
+            brpc::MYSQL_user, brpc::MYSQL_password, brpc::MYSQL_schema);
+        std::stringstream ss;
+        ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+
+        request.Query("show databases");
+
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_RESULTSET, response.reply(0).type());
+    }
+
+    // Auth failed
+    {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_MYSQL;
+        options.connection_type = brpc::MYSQL_connection_type;
+        options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+        options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+        options.auth =
+            new brpc::policy::MysqlAuthenticator(brpc::MYSQL_user, "123456789", brpc::MYSQL_schema);
+        std::stringstream ss;
+        ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+
+        request.Query("show databases");
+
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_TRUE(cntl.Failed()) << cntl.ErrorText();
+    }
+
+    // check noauth.
+    {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_MYSQL;
+        options.connection_type = brpc::MYSQL_connection_type;
+        options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+        options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+        std::stringstream ss;
+        ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+
+        request.Query("show databases");
+
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_TRUE(cntl.Failed()) << cntl.ErrorText();
+    }
+}
+
+TEST_F(MysqlTest, ok) {
+    {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_MYSQL;
+        options.connection_type = brpc::MYSQL_connection_type;
+        options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+        options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+        options.auth = new brpc::policy::MysqlAuthenticator(
+            brpc::MYSQL_user, brpc::MYSQL_password, brpc::MYSQL_schema);
+        std::stringstream ss;
+        ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+
+        request.Query(
+            "CREATE OR REPLACE TABLE `brpc_table` (`col1` int(11) NOT NULL, `col2` varchar(45) "
+            "DEFAULT NULL, "
+            "`col3` decimal(6,3) DEFAULT NULL, `col4` datetime DEFAULT NULL, `col5` blob, `col6` "
+            "binary(6) DEFAULT NULL, `col7` tinyblob, `col8` longblob, `col9` mediumblob, `col10` "
+            "tinyblob, `col11` varbinary(10) DEFAULT NULL, `col12` date DEFAULT NULL, `col13` "
+            "datetime(6) DEFAULT NULL, `col14` time DEFAULT NULL, `col15` timestamp(4) NULL "
+            "DEFAULT NULL, `col16` year(4) DEFAULT NULL, `col17` geometry DEFAULT NULL, `col18` "
+            "geometrycollection DEFAULT NULL, `col19` linestring DEFAULT NULL, `col20` point "
+            "DEFAULT NULL, `col21` polygon DEFAULT NULL, `col22` bigint(64) DEFAULT NULL, `col23` "
+            "decimal(10,0) DEFAULT NULL, `col24` double DEFAULT NULL, `col25` float DEFAULT NULL, "
+            "`col26` int(7) DEFAULT NULL, `col27` mediumint(18) DEFAULT NULL, `col28` double "
+            "DEFAULT NULL, `col29` smallint(2) DEFAULT NULL, `col30` tinyint(1) DEFAULT NULL, "
+            "`col31` char(6) DEFAULT NULL, `col32` varchar(6) DEFAULT NULL, `col33` longtext, "
+            "`col34` mediumtext, `col35` tinytext, `col36` tinytext, `col37` bit(7) DEFAULT NULL, "
+            "`col38` tinyint(4) DEFAULT NULL, `col39` varchar(45) DEFAULT NULL, `col40` "
+            "varchar(45) CHARACTER SET utf8 DEFAULT NULL, `col41` char(4) CHARACTER SET utf8 "
+            "DEFAULT NULL, `col42` varchar(6) CHARACTER SET utf8 DEFAULT NULL, PRIMARY KEY "
+            "(`col1`)) ENGINE=InnoDB DEFAULT CHARSET=utf8");
+
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_OK, response.reply(0).type());
+    }
+
+    {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_MYSQL;
+        options.connection_type = brpc::MYSQL_connection_type;
+        options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+        options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+        options.auth = new brpc::policy::MysqlAuthenticator(
+            brpc::MYSQL_user, brpc::MYSQL_password, brpc::MYSQL_schema);
+        std::stringstream ss;
+        ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+
+        std::stringstream ss1;
+        ss1 << "INSERT INTO `brpc_table` "
+               "(`col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`"
+               ",`"
+               "col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,"
+               "`"
+               "col22`"
+               ",`col23`,`col24`,`col25`,`col26`,`col27`,`col28`,`col29`,`col30`,`col31`,`"
+               "col32`,`"
+               "col33`,`col34`,`col35`,`col36`,`col37`,`col38`,`col39`,`col40`,`col41`,`col42`)"
+               " "
+               "VALUES ("
+            << ++brpc::MYSQL_cnt
+            << ",'col2',0.015,'2018-12-01 "
+               "12:13:14','aaa','bbb','ccc','ddd','eee','fff','ggg','2014-09-18', "
+               "'2010-12-10 14:12:09.019473' ,'01:06:09','1970-01-01 08:00:00.9856'"
+               ",2014,NULL,NULL,NULL,NULL,NULL,69,'12.5',16.9,6.7,24,37,69.56,234,6,"
+               "'"
+               "col31','col32','col33','col34','col35','col36',NULL,9,'col39','col40','col41'"
+               ",'"
+               "col42')";
+        request.Query(ss1.str());
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_OK, response.reply(0).type());
+    }
+}
+
+TEST_F(MysqlTest, error) {
+    {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_MYSQL;
+        options.connection_type = brpc::MYSQL_connection_type;
+        options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+        options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+        options.auth = new brpc::policy::MysqlAuthenticator(
+            brpc::MYSQL_user, brpc::MYSQL_password, brpc::MYSQL_schema);
+        std::stringstream ss;
+        ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+
+        request.Query("select nocol from notable");
+
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_ERROR, response.reply(0).type());
+    }
+}
+
+TEST_F(MysqlTest, resultset) {
+    brpc::ChannelOptions options;
+    options.protocol = brpc::PROTOCOL_MYSQL;
+    options.connection_type = brpc::MYSQL_connection_type;
+    options.connect_timeout_ms = brpc::MYSQL_connect_timeout_ms;
+    options.timeout_ms = brpc::MYSQL_timeout_ms /*milliseconds*/;
+    options.auth = new brpc::policy::MysqlAuthenticator(
+        brpc::MYSQL_user, brpc::MYSQL_password, brpc::MYSQL_schema);
+    std::stringstream ss;
+    ss << brpc::MYSQL_host + ":" + brpc::MYSQL_port;
+    brpc::Channel channel;
+    ASSERT_EQ(0, channel.Init(ss.str().c_str(), &options));
+    {
+        for (int i = 0; i < 50; ++i) {
+            brpc::MysqlRequest request;
+            brpc::MysqlResponse response;
+            brpc::Controller cntl;
+
+            std::stringstream ss1;
+            ss1 << "INSERT INTO `brpc_table` "
+                   "(`col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`"
+                   ",`"
+                   "col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,"
+                   "`"
+                   "col22`"
+                   ",`col23`,`col24`,`col25`,`col26`,`col27`,`col28`,`col29`,`col30`,`col31`,`"
+                   "col32`,`"
+                   "col33`,`col34`,`col35`,`col36`,`col37`,`col38`,`col39`,`col40`,`col41`,`col42`)"
+                   " "
+                   "VALUES ("
+                << ++brpc::MYSQL_cnt
+                << ",'col2',0.015,'2018-12-01 "
+                   "12:13:14','aaa','bbb','ccc','ddd','eee','fff','ggg','2014-09-18', "
+                   "'2010-12-10 14:12:09.019473' ,'01:06:09','1970-01-01 08:00:00.9856'"
+                   ",2014,NULL,NULL,NULL,NULL,NULL,69,'12.5',16.9,6.7,24,37,69.56,234,6,"
+                   "'"
+                   "col31','col32','col33','col34','col35','col36',NULL,9,'col39','col40','"
+                   "col41'"
+                   ",'"
+                   "col42')";
+            request.Query(ss1.str());
+            channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+            ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+            ASSERT_EQ(1, response.reply_size());
+            ASSERT_EQ(brpc::MYSQL_RSP_OK, response.reply(0).type());
+        }
+    }
+
+    {
+        std::stringstream ss1;
+        for (int i = 0; i < 30; ++i) {
+            ss1 << "INSERT INTO `brpc_table` "
+                   "(`col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`"
+                   ",`"
+                   "col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,"
+                   "`"
+                   "col22`"
+                   ",`col23`,`col24`,`col25`,`col26`,`col27`,`col28`,`col29`,`col30`,`col31`,`"
+                   "col32`,`"
+                   "col33`,`col34`,`col35`,`col36`,`col37`,`col38`,`col39`,`col40`,`col41`,`col42`)"
+                   " "
+                   "VALUES ("
+                << ++brpc::MYSQL_cnt
+                << ",'col2',0.015,'2018-12-01 "
+                   "12:13:14','aaa','bbb','ccc','ddd','eee','fff','ggg','2014-09-18', "
+                   "'2010-12-10 14:12:09.019473' ,'01:06:09','1970-01-01 08:00:00.9856'"
+                   ",2014,NULL,NULL,NULL,NULL,NULL,69,'12.5',16.9,6.7,24,37,69.56,234,6,"
+                   "'"
+                   "col31','col32','col33','col34','col35','col36',NULL,9,'col39','col40','"
+                   "col41'"
+                   ",'"
+                   "col42')";
+            ss1 << ";";
+        }
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+        request.Query(ss1.str());
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(30, response.reply_size());
+        for (int i = 0; i < 30; ++i) {
+            ASSERT_EQ(brpc::MYSQL_RSP_OK, response.reply(i).type());
+        }
+    }
+
+    {
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+        request.Query("select count(0) from brpc_table");
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_RESULTSET, response.reply(0).type());
+    }
+
+    {
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+        request.Query("select * from brpc_table");
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_RESULTSET, response.reply(0).type());
+        ASSERT_EQ(42ull, response.reply(0).column_number());
+        const brpc::MysqlReply& reply = response.reply(0);
+        ASSERT_EQ(reply.column(0)->name(), "col1");
+        ASSERT_EQ(reply.column(0)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(0)->type(), brpc::MYSQL_FIELD_TYPE_LONG);
+
+        ASSERT_EQ(reply.column(1)->name(), "col2");
+        ASSERT_EQ(reply.column(1)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(1)->type(), brpc::MYSQL_FIELD_TYPE_VAR_STRING);
+
+        ASSERT_EQ(reply.column(2)->name(), "col3");
+        ASSERT_EQ(reply.column(2)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(2)->type(), brpc::MYSQL_FIELD_TYPE_NEWDECIMAL);
+
+        ASSERT_EQ(reply.column(3)->name(), "col4");
+        ASSERT_EQ(reply.column(3)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(3)->type(), brpc::MYSQL_FIELD_TYPE_DATETIME);
+
+        ASSERT_EQ(reply.column(4)->name(), "col5");
+        ASSERT_EQ(reply.column(4)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(4)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(5)->name(), "col6");
+        ASSERT_EQ(reply.column(5)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(5)->type(), brpc::MYSQL_FIELD_TYPE_STRING);
+
+        ASSERT_EQ(reply.column(6)->name(), "col7");
+        ASSERT_EQ(reply.column(6)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(6)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(7)->name(), "col8");
+        ASSERT_EQ(reply.column(7)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(7)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(8)->name(), "col9");
+        ASSERT_EQ(reply.column(8)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(8)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(9)->name(), "col10");
+        ASSERT_EQ(reply.column(9)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(9)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(10)->name(), "col11");
+        ASSERT_EQ(reply.column(10)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(10)->type(), brpc::MYSQL_FIELD_TYPE_VAR_STRING);
+
+        ASSERT_EQ(reply.column(11)->name(), "col12");
+        ASSERT_EQ(reply.column(11)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(11)->type(), brpc::MYSQL_FIELD_TYPE_DATE);
+
+        ASSERT_EQ(reply.column(12)->name(), "col13");
+        ASSERT_EQ(reply.column(12)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(12)->type(), brpc::MYSQL_FIELD_TYPE_DATETIME);
+
+        ASSERT_EQ(reply.column(13)->name(), "col14");
+        ASSERT_EQ(reply.column(13)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(13)->type(), brpc::MYSQL_FIELD_TYPE_TIME);
+
+        ASSERT_EQ(reply.column(14)->name(), "col15");
+        ASSERT_EQ(reply.column(14)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(14)->type(), brpc::MYSQL_FIELD_TYPE_TIMESTAMP);
+
+        ASSERT_EQ(reply.column(15)->name(), "col16");
+        ASSERT_EQ(reply.column(15)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(15)->type(), brpc::MYSQL_FIELD_TYPE_YEAR);
+
+        ASSERT_EQ(reply.column(16)->name(), "col17");
+        ASSERT_EQ(reply.column(16)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(16)->type(), brpc::MYSQL_FIELD_TYPE_GEOMETRY);
+
+        ASSERT_EQ(reply.column(17)->name(), "col18");
+        ASSERT_EQ(reply.column(17)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(17)->type(), brpc::MYSQL_FIELD_TYPE_GEOMETRY);
+
+        ASSERT_EQ(reply.column(18)->name(), "col19");
+        ASSERT_EQ(reply.column(18)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(18)->type(), brpc::MYSQL_FIELD_TYPE_GEOMETRY);
+
+        ASSERT_EQ(reply.column(19)->name(), "col20");
+        ASSERT_EQ(reply.column(19)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(19)->type(), brpc::MYSQL_FIELD_TYPE_GEOMETRY);
+
+        ASSERT_EQ(reply.column(20)->name(), "col21");
+        ASSERT_EQ(reply.column(20)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(20)->type(), brpc::MYSQL_FIELD_TYPE_GEOMETRY);
+
+        ASSERT_EQ(reply.column(21)->name(), "col22");
+        ASSERT_EQ(reply.column(21)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(21)->type(), brpc::MYSQL_FIELD_TYPE_LONGLONG);
+
+        ASSERT_EQ(reply.column(22)->name(), "col23");
+        ASSERT_EQ(reply.column(22)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(22)->type(), brpc::MYSQL_FIELD_TYPE_NEWDECIMAL);
+
+        ASSERT_EQ(reply.column(23)->name(), "col24");
+        ASSERT_EQ(reply.column(23)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(23)->type(), brpc::MYSQL_FIELD_TYPE_DOUBLE);
+
+        ASSERT_EQ(reply.column(24)->name(), "col25");
+        ASSERT_EQ(reply.column(24)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(24)->type(), brpc::MYSQL_FIELD_TYPE_FLOAT);
+
+        ASSERT_EQ(reply.column(25)->name(), "col26");
+        ASSERT_EQ(reply.column(25)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(25)->type(), brpc::MYSQL_FIELD_TYPE_LONG);
+
+        ASSERT_EQ(reply.column(26)->name(), "col27");
+        ASSERT_EQ(reply.column(26)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(26)->type(), brpc::MYSQL_FIELD_TYPE_INT24);
+
+        ASSERT_EQ(reply.column(27)->name(), "col28");
+        ASSERT_EQ(reply.column(27)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(27)->type(), brpc::MYSQL_FIELD_TYPE_DOUBLE);
+
+        ASSERT_EQ(reply.column(28)->name(), "col29");
+        ASSERT_EQ(reply.column(28)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(28)->type(), brpc::MYSQL_FIELD_TYPE_SHORT);
+
+        ASSERT_EQ(reply.column(29)->name(), "col30");
+        ASSERT_EQ(reply.column(29)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(29)->type(), brpc::MYSQL_FIELD_TYPE_TINY);
+
+        ASSERT_EQ(reply.column(30)->name(), "col31");
+        ASSERT_EQ(reply.column(30)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(30)->type(), brpc::MYSQL_FIELD_TYPE_STRING);
+
+        ASSERT_EQ(reply.column(31)->name(), "col32");
+        ASSERT_EQ(reply.column(31)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(31)->type(), brpc::MYSQL_FIELD_TYPE_VAR_STRING);
+
+        ASSERT_EQ(reply.column(32)->name(), "col33");
+        ASSERT_EQ(reply.column(32)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(32)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(33)->name(), "col34");
+        ASSERT_EQ(reply.column(33)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(33)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(34)->name(), "col35");
+        ASSERT_EQ(reply.column(34)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(34)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(35)->name(), "col36");
+        ASSERT_EQ(reply.column(35)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(35)->type(), brpc::MYSQL_FIELD_TYPE_BLOB);
+
+        ASSERT_EQ(reply.column(36)->name(), "col37");
+        ASSERT_EQ(reply.column(36)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(36)->type(), brpc::MYSQL_FIELD_TYPE_BIT);
+
+        ASSERT_EQ(reply.column(37)->name(), "col38");
+        ASSERT_EQ(reply.column(37)->collation(), brpc::MYSQL_binary);
+        ASSERT_EQ(reply.column(37)->type(), brpc::MYSQL_FIELD_TYPE_TINY);
+
+        ASSERT_EQ(reply.column(38)->name(), "col39");
+        ASSERT_EQ(reply.column(38)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(38)->type(), brpc::MYSQL_FIELD_TYPE_VAR_STRING);
+
+        ASSERT_EQ(reply.column(39)->name(), "col40");
+        ASSERT_EQ(reply.column(39)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(39)->type(), brpc::MYSQL_FIELD_TYPE_VAR_STRING);
+
+        ASSERT_EQ(reply.column(40)->name(), "col41");
+        ASSERT_EQ(reply.column(40)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(40)->type(), brpc::MYSQL_FIELD_TYPE_STRING);
+
+        ASSERT_EQ(reply.column(41)->name(), "col42");
+        ASSERT_EQ(reply.column(41)->collation(), brpc::MYSQL_utf8_general_ci);
+        ASSERT_EQ(reply.column(41)->type(), brpc::MYSQL_FIELD_TYPE_VAR_STRING);
+
+        int i = 0;
+        const brpc::MysqlReply::Row* row;
+        while ((row = reply.next()) != NULL) {
+            ASSERT_EQ(row->field(0).sinteger(), ++i);
+            ASSERT_EQ(row->field(1).string(), "col2");
+            ASSERT_EQ(row->field(2).string(), "0.015");
+            ASSERT_EQ(row->field(3).string(), "2018-12-01 12:13:14");
+            ASSERT_EQ(row->field(4).string(), "aaa");
+            butil::StringPiece field5 = row->field(5).string();
+            ASSERT_EQ(field5.size(), size_t(6));
+            ASSERT_EQ(field5[0], 'b');
+            ASSERT_EQ(field5[1], 'b');
+            ASSERT_EQ(field5[2], 'b');
+            ASSERT_EQ(field5[3], '\0');
+            ASSERT_EQ(field5[4], '\0');
+            ASSERT_EQ(field5[5], '\0');
+            ASSERT_EQ(row->field(6).string(), "ccc");
+            ASSERT_EQ(row->field(7).string(), "ddd");
+            ASSERT_EQ(row->field(8).string(), "eee");
+            ASSERT_EQ(row->field(9).string(), "fff");
+            ASSERT_EQ(row->field(10).string(), "ggg");
+            ASSERT_EQ(row->field(11).string(), "2014-09-18");
+            ASSERT_EQ(row->field(12).string(), "2010-12-10 14:12:09.019473");
+            ASSERT_EQ(row->field(13).string(), "01:06:09");
+            ASSERT_EQ(row->field(14).string(), "1970-01-01 08:00:00.9856");
+            ASSERT_EQ(row->field(15).small(), uint16_t(2014));
+            ASSERT_EQ(row->field(16).is_nil(), true);
+            ASSERT_EQ(row->field(17).is_nil(), true);
+            ASSERT_EQ(row->field(18).is_nil(), true);
+            ASSERT_EQ(row->field(19).is_nil(), true);
+            ASSERT_EQ(row->field(20).is_nil(), true);
+            ASSERT_EQ(row->field(21).sbigint(), int64_t(69));
+            ASSERT_EQ(row->field(22).string(), "13");
+            ASSERT_EQ(row->field(23).float64(), double(16.9));
+            ASSERT_EQ(row->field(24).float32(), float(6.7));
+            ASSERT_EQ(row->field(25).sinteger(), int32_t(24));
+            ASSERT_EQ(row->field(26).sinteger(), int32_t(37));
+            ASSERT_EQ(row->field(27).float64(), double(69.56));
+            ASSERT_EQ(row->field(28).ssmall(), int16_t(234));
+            ASSERT_EQ(row->field(29).stiny(), '6');
+            ASSERT_EQ(row->field(30).string(), "col31");
+            ASSERT_EQ(row->field(31).string(), "col32");
+            ASSERT_EQ(row->field(32).string(), "col33");
+            ASSERT_EQ(row->field(33).string(), "col34");
+            ASSERT_EQ(row->field(34).string(), "col35");
+            ASSERT_EQ(row->field(35).string(), "col36");
+            ASSERT_EQ(row->field(36).is_nil(), true);
+            ASSERT_EQ(row->field(37).stiny(), '9');
+            ASSERT_EQ(row->field(38).string(), "col39");
+            ASSERT_EQ(row->field(39).string(), "col40");
+            ASSERT_EQ(row->field(40).string(), "col4");  // size is 4
+            ASSERT_EQ(row->field(41).string(), "col42");
+        }
+    }
+
+    {
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+        request.Query("delete from brpc_table");
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_OK, response.reply(0).type());
+    }
+
+    {
+        brpc::MysqlRequest request;
+        brpc::MysqlResponse response;
+        brpc::Controller cntl;
+        request.Query("drop table brpc_table");
+        channel.CallMethod(NULL, &cntl, &request, &response, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.reply_size());
+        ASSERT_EQ(brpc::MYSQL_RSP_OK, response.reply(0).type());
+    }
+}
+
+}  // namespace


### PR DESCRIPTION
brpc只支持MySQL 4.1 及之后的版本的文本协议。目前还不支持事务、Prepare statement，未来将会支持。目前支持的鉴权方式为mysql_native_password