### PR TITLE
CircuitBreaker： fix race condition， adjust reset policy

### DIFF
--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -85,7 +85,6 @@ private:
     int64_t _last_reset_time_ms;
     butil::atomic<int> _isolation_duration_ms;
     butil::atomic<int> _isolated_times;
-    butil::atomic<bool> _is_first_call_after_revived;
     butil::atomic<bool> _broken;
 };
 

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -82,7 +82,7 @@ private:
 
     EmaErrorRecorder _long_window;
     EmaErrorRecorder _short_window;
-    butil::atomic<int64_t> _last_revived_time_ms;
+    int64_t _last_reset_time_ms;
     butil::atomic<int> _isolation_duration_ms;
     butil::atomic<int> _isolated_times;
     butil::atomic<bool> _is_first_call_after_revived;

--- a/src/brpc/circuit_breaker.h
+++ b/src/brpc/circuit_breaker.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 Baidu, Inc.G
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 
 #ifndef BRPC_CIRCUIT_BREAKER_H
 #define BRPC_CIRCUIT_BREAKER_H
-                                            
+
 #include "butil/atomicops.h"
 
 namespace brpc {
@@ -27,22 +27,22 @@ public:
 
     ~CircuitBreaker() {}
 
-    // Sampling the current rpc. Returns false if a node needs to 
+    // Sampling the current rpc. Returns false if a node needs to
     // be isolated. Otherwise return true.
     // error_code: Error_code of this call, 0 means success.
     // latency: Time cost of this call.
     // Note: Once OnCallEnd() determined that a node needs to be isolated,
-    // it will always return false until you call Reset(). Usually Reset() 
+    // it will always return false until you call Reset(). Usually Reset()
     // will be called in the health check thread.
     bool OnCallEnd(int error_code, int64_t latency);
 
-    // Reset CircuitBreaker and clear history data. will erase the historical 
+    // Reset CircuitBreaker and clear history data. will erase the historical
     // data and start sampling again. Before you call this method, you need to
     // ensure that no one else is accessing CircuitBreaker.
     void Reset();
 
-    // Mark the Socket as broken. Call this method when you want to isolate a 
-    // node in advance. When this method is called multiple times in succession, 
+    // Mark the Socket as broken. Call this method when you want to isolate a
+    // node in advance. When this method is called multiple times in succession,
     // only the first call will take effect.
     void MarkAsBroken();
 
@@ -82,9 +82,10 @@ private:
 
     EmaErrorRecorder _long_window;
     EmaErrorRecorder _short_window;
-    int64_t _last_reset_time_ms; 
+    butil::atomic<int64_t> _last_revived_time_ms;
     butil::atomic<int> _isolation_duration_ms;
     butil::atomic<int> _isolated_times;
+    butil::atomic<bool> _is_first_call_after_revived;
     butil::atomic<bool> _broken;
 };
 

--- a/test/brpc_circuit_breaker_unittest.cpp
+++ b/test/brpc_circuit_breaker_unittest.cpp
@@ -110,7 +110,7 @@ protected:
             FeedbackControl* fc =
                 new FeedbackControl(2 * kLongWindowSize, error_percent, &_circuit_breaker);
             fc_list->emplace_back(fc);
-            pthread_create(&tid, NULL, feed_back_thread, fc);
+            pthread_create(&tid, nullptr, feed_back_thread, fc);
             thread_list->push_back(tid);
         }
     }
@@ -123,7 +123,7 @@ TEST_F(CircuitBreakerTest, should_not_isolate) {
     std::vector<std::unique_ptr<FeedbackControl>> fc_list;
     StartFeedbackThread(&thread_list, &fc_list, 3);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_EQ(fc->_unhealthy_cnt, 0);
@@ -136,7 +136,7 @@ TEST_F(CircuitBreakerTest, should_isolate) {
     std::vector<std::unique_ptr<FeedbackControl>> fc_list;
     StartFeedbackThread(&thread_list, &fc_list, 50);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_GT(fc->_unhealthy_cnt, 0);
@@ -150,7 +150,7 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
     std::vector<std::unique_ptr<FeedbackControl>> fc_list;
     StartFeedbackThread(&thread_list, &fc_list, 100);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
@@ -162,7 +162,7 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
     _circuit_breaker.Reset();
     StartFeedbackThread(&thread_list, &fc_list, 100);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
@@ -174,7 +174,7 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
     _circuit_breaker.Reset();
     StartFeedbackThread(&thread_list, &fc_list, 100);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
@@ -192,7 +192,7 @@ TEST_F(CircuitBreakerTest, isolation_duration_reset) {
     ::usleep((kMaxIsolationDurationMs + kMinIsolationDurationMs) * 1000);
     StartFeedbackThread(&thread_list, &fc_list, 100);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);
@@ -209,7 +209,7 @@ TEST_F(CircuitBreakerTest, isolation_duration_compute) {
     ::usleep((kMaxIsolationDurationMs + kMinIsolationDurationMs) * 1000);
     StartFeedbackThread(&thread_list, &fc_list, 100);
     for (int  i = 0; i < kThreadNum; ++i) {
-        void* ret_data = NULL;
+        void* ret_data = nullptr;
         EXPECT_EQ(pthread_join(thread_list[i], &ret_data), 0);
         FeedbackControl* fc = static_cast<FeedbackControl*>(ret_data);
         EXPECT_FALSE(fc->_healthy);

--- a/test/brpc_circuit_breaker_unittest.cpp
+++ b/test/brpc_circuit_breaker_unittest.cpp
@@ -172,7 +172,6 @@ TEST_F(CircuitBreakerTest, isolation_duration_grow) {
     EXPECT_EQ(_circuit_breaker.isolation_duration_ms(), kMinIsolationDurationMs * 4);
 
     _circuit_breaker.Reset();
-    ::usleep((kMaxIsolationDurationMs + kMinIsolationDurationMs) * 1000);
     StartFeedbackThread(&thread_list, &fc_list, 100);
     for (int  i = 0; i < kThreadNum; ++i) {
         void* ret_data = NULL;


### PR DESCRIPTION
1. fix sp->circuit_breaker->Reset() 时可能存在的data race
2. 调整CircuitBreaker::Reset的策略，Reset之后，如果已经经过了初始化阶段，则继续使用之前ema_latency。如果Reset的时候还处于初始化阶段，则丢弃之前积累的数据