### PR TITLE
Fix compilation errors caused by ssl on MacOS

### DIFF
--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -136,6 +136,9 @@ find_dir_of_header_or_die() {
     $ECHO $dir
 }
 
+# User specified path of openssl, if not given it's empty
+OPENSSL_LIB=$(find_dir_of_lib ssl)
+
 # Inconvenient to check these headers in baidu-internal
 #PTHREAD_HDR=$(find_dir_of_header_or_die pthread.h)
 OPENSSL_HDR=$(find_dir_of_header_or_die openssl/ssl.h)
@@ -233,7 +236,7 @@ PROTOBUF_HDR=$(find_dir_of_header_or_die google/protobuf/message.h)
 LEVELDB_HDR=$(find_dir_of_header_or_die leveldb/db.h)
 
 HDRS=$($ECHO "$GFLAGS_HDR\n$PROTOBUF_HDR\n$LEVELDB_HDR\n$OPENSSL_HDR" | sort | uniq)
-LIBS=$($ECHO "$GFLAGS_LIB\n$PROTOBUF_LIB\n$LEVELDB_LIB\n$SNAPPY_LIB" | sort | uniq)
+LIBS=$($ECHO "$GFLAGS_LIB\n$PROTOBUF_LIB\n$LEVELDB_LIB\n$OPENSSL_LIB\n$SNAPPY_LIB" | sort | uniq)
 
 absent_in_the_list() {
     TMP=`$ECHO "$1\n$2" | sort | uniq`


### PR DESCRIPTION
Bug report: #769 

Related issue: #328 #360 #666 #723 #726

According to the [instruction](https://github.com/apache/incubator-brpc/blob/master/docs/cn/getting_started.md)
given by incubator-brpc, openssl seems to be an optional lib but it is required
on all platforms, despite that openssl may be installed by default and no need
to install manually. 

However, openssl is not trusted by Apple due to [heartbleed](https://en.m.wikipedia.org/wiki/Heartbleed),
if we need to get openssl support, we need to install it manually.

We can compile/install leveldb, gflags, openssl, openssl, protobuf on mac by
simply using the package manager called `brew` as suggested by the brpc
installation instruction, or install by hand with `autotools + libtool + pkg-config` 
from source code published on github (or somewhere).

`brew` does a lot for users, however, users usually don't know what's under
the hood and the pkg installation path may differ for different users, which
may make compilation fail.

e.g fails to link openssl when we build brpc on mac

```
Linking libbrpc.dylib
Linking protoc-gen-mcpack
Copying to output/include
Undefined symbols for architecture x86_64:
  "_BN_get_rfc2409_prime_1024", referenced from:
      brpc::SSLDHInit() in ssl_helper.o
      brpc::policy::DHWrapper::do_initialize() in dh.o
  "_BN_get_rfc3526_prime_2048", referenced from:
      brpc::SSLDHInit() in ssl_helper.o
  "_BN_get_rfc3526_prime_4096", referenced from:
      brpc::SSLDHInit() in ssl_helper.o
  "_BN_get_rfc3526_prime_8192", referenced from:
```

To fix that, **we should treat libopenssl as a normal, not default, library**
needed by brpc, just the same as leveldb or gflags.

```
--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -136,6 +136,9 @@ find_dir_of_header_or_die() {
     $ECHO $dir
 }

+# User specified path of lib openssl, if not given it's empty
+OPENSSL_LIB=$(find_dir_of_lib ssl)
+
 # Inconvenient to check these headers in baidu-internal
 #PTHREAD_HDR=$(find_dir_of_header_or_die pthread.h)
 OPENSSL_HDR=$(find_dir_of_header_or_die openssl/ssl.h)
@@ -233,7 +236,7 @@ PROTOBUF_HDR=$(find_dir_of_header_or_die google/protobuf/message.h)
 LEVELDB_HDR=$(find_dir_of_header_or_die leveldb/db.h)

 HDRS=$($ECHO "$GFLAGS_HDR\n$PROTOBUF_HDR\n$LEVELDB_HDR\n$OPENSSL_HDR" | sort | uniq)
-LIBS=$($ECHO "$GFLAGS_LIB\n$PROTOBUF_LIB\n$LEVELDB_LIB\n$SNAPPY_LIB" | sort | uniq)
+LIBS=$($ECHO "$GFLAGS_LIB\n$PROTOBUF_LIB\n$LEVELDB_LIB\n$OPENSSL_LIB\n$SNAPPY_LIB" | sort | uniq)
```

With this patch, 
users can specify libopenssl when run  `config_brpc.sh` with option
`--libs="... ${path_to_libopenssl} ..."`, in which `path_to_libopenssl` may be
one of `/usr/local/lib`, `/usr/local/opt/lib`,
`/users/gavin/installed-from-src/openssl/lib` and etc.

If you failed to compile due to openssl, try to change the above lib path.

I think it's the purpose of option `--libs`. The original `config_brpc.sh`
treats openssl as a default library instead of a normal library, that may be not
correct.

The above patch should fix all the following issues or pull request:  
* MacOS安装make报错 #328
* macos 10.12.6 make出错 #360
* Mac下链接生成动态库失败 #666
* mac 10.13.6 编译出错 #726
* fix build scripts under mac os env and add building section for README #723

(There may be more issues which I didn't find.)

This is an example of compilation error caused by openssl when we build brpc, 
we can do the same to resolve other compilation error related to libs, including
version issues of libs.
