### PR TITLE
Improve cmake: make unit tests link against the brpc shared library ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ set(SOURCES
 
 add_subdirectory(src)
 if(BUILD_UNIT_TESTS)
+    enable_testing()
     add_subdirectory(test)
 endif()
 add_subdirectory(tools)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,9 +174,9 @@ endif()
 
 # create executable
 add_executable(test_butil ${TEST_BUTIL_SOURCES}
-                          ${CMAKE_CURRENT_BINARY_DIR}/iobuf.pb.cc
-                          $<TARGET_OBJECTS:BUTIL_LIB>)
-target_link_libraries(test_butil gtest
+                          ${CMAKE_CURRENT_BINARY_DIR}/iobuf.pb.cc)
+target_link_libraries(test_butil brpc-shared
+                                 gtest
                                  ${GPERFTOOLS_LIBRARIES}
                                  ${DYNAMIC_LIB})
 
@@ -185,10 +185,9 @@ list(REMOVE_ITEM BVAR_SOURCES ${PROJECT_SOURCE_DIR}/src/bvar/default_variables.c
 
 add_library(BVAR_OBJ OBJECT ${BVAR_SOURCES})
 file(GLOB TEST_BVAR_SRCS "bvar_*_unittest.cpp")
-add_executable(test_bvar $<TARGET_OBJECTS:BUTIL_LIB>
-                         $<TARGET_OBJECTS:BVAR_OBJ>
-                         ${TEST_BVAR_SRCS})
-target_link_libraries(test_bvar gtest
+add_executable(test_bvar ${TEST_BVAR_SRCS})
+target_link_libraries(test_bvar brpc-shared
+                                gtest
                                 ${GPERFTOOLS_LIBRARIES}
                                 ${DYNAMIC_LIB})
 
@@ -197,29 +196,20 @@ add_library(PROTO_OBJ OBJECT ${PROTO_SRCS})
 file(GLOB BTHREAD_UNITTESTS "bthread*unittest.cpp")
 foreach(BTHREAD_UT ${BTHREAD_UNITTESTS})
     get_filename_component(BTHREAD_UT_WE ${BTHREAD_UT} NAME_WE)
-    add_executable(${BTHREAD_UT_WE} ${BTHREAD_UT} 
-                                    $<TARGET_OBJECTS:BUTIL_LIB>
-                                    $<TARGET_OBJECTS:BVAR_OBJ>
-                                    $<TARGET_OBJECTS:BTHREAD_OBJ>
-                                    $<TARGET_OBJECTS:PROTO_LIB>
-                                    $<TARGET_OBJECTS:TEST_PROTO_LIB>)
-    target_link_libraries(${BTHREAD_UT_WE}
-                          gtest_main
-                          ${GPERFTOOLS_LIBRARIES}
-                          ${DYNAMIC_LIB})
+    add_executable(${BTHREAD_UT_WE} ${BTHREAD_UT} $<TARGET_OBJECTS:TEST_PROTO_LIB>)
+    target_link_libraries(${BTHREAD_UT_WE} brpc-shared
+                                           gtest_main
+                                           ${GPERFTOOLS_LIBRARIES}
+                                           ${DYNAMIC_LIB})
 endforeach()
 
 file(GLOB BRPC_UNITTESTS "brpc_*_unittest.cpp")
 foreach(BRPC_UT ${BRPC_UNITTESTS})
     get_filename_component(BRPC_UT_WE ${BRPC_UT} NAME_WE)
-    add_executable(${BRPC_UT_WE} ${BRPC_UT}
-                                 $<TARGET_OBJECTS:TEST_PROTO_LIB>
-                                 $<TARGET_OBJECTS:BUTIL_LIB>
-                                 $<TARGET_OBJECTS:OBJ_LIB>
-                                 $<TARGET_OBJECTS:PROTO_LIB>)
-    target_link_libraries(${BRPC_UT_WE}
-                          gtest_main
-                          ${GPERFTOOLS_LIBRARIES}
-                          ${GTEST_LIB}
-                          ${DYNAMIC_LIB})
+    add_executable(${BRPC_UT_WE} ${BRPC_UT} $<TARGET_OBJECTS:TEST_PROTO_LIB>)
+    target_link_libraries(${BRPC_UT_WE} brpc-shared
+                                        gtest_main
+                                        ${GPERFTOOLS_LIBRARIES}
+                                        ${GTEST_LIB}
+                                        ${DYNAMIC_LIB})
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,28 +179,35 @@ target_link_libraries(test_butil brpc-shared
                                  gtest
                                  ${GPERFTOOLS_LIBRARIES}
                                  ${DYNAMIC_LIB})
+add_test(NAME test_butil COMMAND test_butil)
 
 # -DBVAR_NOT_LINK_DEFAULT_VARIABLES not work for gcc >= 5.0, just remove the file to prevent linking into unit tests
 list(REMOVE_ITEM BVAR_SOURCES ${PROJECT_SOURCE_DIR}/src/bvar/default_variables.cpp)
 
 add_library(BVAR_OBJ OBJECT ${BVAR_SOURCES})
 file(GLOB TEST_BVAR_SRCS "bvar_*_unittest.cpp")
-add_executable(test_bvar ${TEST_BVAR_SRCS})
-target_link_libraries(test_bvar brpc-shared
-                                gtest
+add_executable(test_bvar ${TEST_BVAR_SRCS} $<TARGET_OBJECTS:BVAR_OBJ> $<TARGET_OBJECTS:BUTIL_LIB>)
+target_link_libraries(test_bvar gtest
                                 ${GPERFTOOLS_LIBRARIES}
                                 ${DYNAMIC_LIB})
+add_test(NAME test_bvar COMMAND test_bvar)
 
 add_library(BTHREAD_OBJ OBJECT ${BTHREAD_SOURCES})
 add_library(PROTO_OBJ OBJECT ${PROTO_SRCS})
 file(GLOB BTHREAD_UNITTESTS "bthread*unittest.cpp")
 foreach(BTHREAD_UT ${BTHREAD_UNITTESTS})
     get_filename_component(BTHREAD_UT_WE ${BTHREAD_UT} NAME_WE)
-    add_executable(${BTHREAD_UT_WE} ${BTHREAD_UT} $<TARGET_OBJECTS:TEST_PROTO_LIB>)
-    target_link_libraries(${BTHREAD_UT_WE} brpc-shared
-                                           gtest_main
+    add_executable(${BTHREAD_UT_WE} ${BTHREAD_UT}
+                                    $<TARGET_OBJECTS:BUTIL_LIB>
+                                    $<TARGET_OBJECTS:BVAR_OBJ>
+                                    $<TARGET_OBJECTS:BTHREAD_OBJ>
+                                    $<TARGET_OBJECTS:PROTO_LIB>
+                                    $<TARGET_OBJECTS:TEST_PROTO_LIB>
+                                    )
+    target_link_libraries(${BTHREAD_UT_WE} gtest_main
                                            ${GPERFTOOLS_LIBRARIES}
                                            ${DYNAMIC_LIB})
+    add_test(NAME ${BTHREAD_UT_WE} COMMAND ${BTHREAD_UT_WE})
 endforeach()
 
 file(GLOB BRPC_UNITTESTS "brpc_*_unittest.cpp")
@@ -212,4 +219,5 @@ foreach(BRPC_UT ${BRPC_UNITTESTS})
                                         ${GPERFTOOLS_LIBRARIES}
                                         ${GTEST_LIB}
                                         ${DYNAMIC_LIB})
+    add_test(NAME ${BRPC_UT_WE} COMMAND ${BRPC_UT_WE})
 endforeach()

--- a/test/brpc_server_unittest.cpp
+++ b/test/brpc_server_unittest.cpp
@@ -1158,7 +1158,7 @@ TEST_F(ServerTest, serving_requests) {
 TEST_F(ServerTest, create_pid_file) {
     {
         brpc::Server server;
-        server._options.pid_file = "$PWD//pid_dir/sub_dir/./.server.pid";
+        server._options.pid_file = "./pid_dir/sub_dir/./.server.pid";
         server.PutPidFileIfNeeded();
         pid_t pid = getpid();
         std::ifstream fin("./pid_dir/sub_dir/.server.pid");


### PR DESCRIPTION
... so that we don't build a world of huge binaries that are forced to take every single piece of object files from those object library targets.
Test binaries down size from somewhat 6GB to around 600M. Linking is also vastly speeded up.