### PR TITLE
fix _avg_latency maybe zero

### DIFF
--- a/src/brpc/policy/locality_aware_load_balancer.cpp
+++ b/src/brpc/policy/locality_aware_load_balancer.cpp
@@ -457,6 +457,9 @@ int64_t LocalityAwareLoadBalancer::Weight::Update(
         // or time skews, we don't update the weight for safety.
         return 0;
     }
+    if (_avg_latency == 0) {
+        return 0;
+    }
     _base_weight = scaled_qps / _avg_latency;
     return ResetWeight(index, end_time_us);
 }


### PR DESCRIPTION
To avoid zero exception.

Fix: https://github.com/apache/incubator-brpc/issues/898

(This is a Baidu internal modification)