### PR TITLE
Support symlink for config find_bin

### DIFF
--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -117,7 +117,7 @@ find_dir_of_lib_or_die() {
 }
 
 find_bin() {
-    TARGET_BIN=$(find ${LIBS_IN} -type f -name "$1" 2>/dev/null | head -n1)
+    TARGET_BIN=$(find -L ${LIBS_IN} -type f -name "$1" 2>/dev/null | head -n1)
     if [ ! -z "$TARGET_BIN" ]; then
         $ECHO $TARGET_BIN
     else


### PR DESCRIPTION
For example, to configure the brpc build with self-built version of protobuf/protoc, like this:

```
$ ll third_party/install/protobuf/bin/
total 57412
drwxrwxr-x 2 heliangliang heliangliang     4096 Oct  8 10:58 ./
drwxrwxr-x 5 heliangliang heliangliang     4096 Oct  8 10:58 ../
lrwxrwxrwx 1 heliangliang heliangliang       14 Oct  8 10:58 protoc -> protoc-3.8.0.0*
-rwxr-xr-x 1 heliangliang heliangliang 58780232 Oct  8 10:58 protoc-3.8.0.0*
```

The current script won't find the protoc without `-L` option.