### PR TITLE
Fix thread_local in clang

### DIFF
--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -28,9 +28,7 @@
 // Provide thread_local keyword (for primitive types) before C++11
 // DEPRECATED: define this keyword before C++11 might make the variable ABI
 // incompatible between C++11 and C++03
-#if !defined(thread_local) &&                                           \
-    (__cplusplus < 201103L ||                                           \
-     (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40800)
+#if !defined(thread_local) && !defined(BUTIL_CXX11_ENABLED)
 // GCC supports thread_local keyword of C++11 since 4.8.0
 #ifdef _MSC_VER
 // WARNING: don't use this macro in C++03


### PR DESCRIPTION
when building with **clang** and c++11, the c++11 check with `__GNUC__` and `__GNUC_MINOR__` macro will not pass, and there will be a macro `# define thread_local __thread`, which is not expected