### PR TITLE
add zone for bili discovery in fetching server nodes

### DIFF
--- a/src/brpc/policy/discovery_naming_service.cpp
+++ b/src/brpc/policy/discovery_naming_service.cpp
@@ -41,7 +41,7 @@ DEFINE_string(discovery_api_addr, DEFAULT_DISCOVERY_API_ADDR, "The address of di
 DEFINE_int32(discovery_timeout_ms, 3000, "Timeout for discovery requests");
 DEFINE_string(discovery_env, "prod", "Environment of services");
 DEFINE_string(discovery_status, "1", "Status of services. 1 for ready, 2 for not ready, 3 for all");
-DEFINE_string(discovery_zone, "", "Zone of  services");
+DEFINE_string(discovery_zone, "", "Zone of services");
 DEFINE_int32(discovery_renew_interval_s, 30, "The interval between two consecutive renews");
 DEFINE_int32(discovery_reregister_threshold, 3, "The renew error threshold beyond"
         " which Register would be called again");
@@ -353,7 +353,7 @@ int DiscoveryNamingService::GetServers(const char* service_name,
             "/discovery/fetchs?appid=%s&env=%s&status=%s", service_name,
             FLAGS_discovery_env.c_str(), FLAGS_discovery_status.c_str());
     if (!FLAGS_discovery_zone.empty()) {
-        uri_str.append("&zone=", 6);
+        uri_str.append("&zone=");
         uri_str.append(FLAGS_discovery_zone);
     }
     cntl.http_request().uri() = uri_str;

--- a/src/brpc/policy/discovery_naming_service.cpp
+++ b/src/brpc/policy/discovery_naming_service.cpp
@@ -41,6 +41,7 @@ DEFINE_string(discovery_api_addr, DEFAULT_DISCOVERY_API_ADDR, "The address of di
 DEFINE_int32(discovery_timeout_ms, 3000, "Timeout for discovery requests");
 DEFINE_string(discovery_env, "prod", "Environment of services");
 DEFINE_string(discovery_status, "1", "Status of services. 1 for ready, 2 for not ready, 3 for all");
+DEFINE_string(discovery_zone, "", "Zone of  services");
 DEFINE_int32(discovery_renew_interval_s, 30, "The interval between two consecutive renews");
 DEFINE_int32(discovery_reregister_threshold, 3, "The renew error threshold beyond"
         " which Register would be called again");
@@ -349,8 +350,9 @@ int DiscoveryNamingService::GetServers(const char* service_name,
     servers->clear();
     Controller cntl;
     cntl.http_request().uri() = butil::string_printf(
-            "/discovery/fetchs?appid=%s&env=%s&status=%s", service_name,
-            FLAGS_discovery_env.c_str(), FLAGS_discovery_status.c_str());
+            "/discovery/fetchs?appid=%s&env=%s&status=%s&zone=%s", service_name,
+            FLAGS_discovery_env.c_str(), FLAGS_discovery_status.c_str(),
+            FLAGS_discovery_zone.c_str());
     chan->CallMethod(NULL, &cntl, NULL, NULL, NULL);
     if (cntl.Failed()) {
         LOG(ERROR) << "Fail to get /discovery/fetchs: " << cntl.ErrorText();

--- a/src/brpc/policy/discovery_naming_service.cpp
+++ b/src/brpc/policy/discovery_naming_service.cpp
@@ -349,10 +349,14 @@ int DiscoveryNamingService::GetServers(const char* service_name,
     }
     servers->clear();
     Controller cntl;
-    cntl.http_request().uri() = butil::string_printf(
-            "/discovery/fetchs?appid=%s&env=%s&status=%s&zone=%s", service_name,
-            FLAGS_discovery_env.c_str(), FLAGS_discovery_status.c_str(),
-            FLAGS_discovery_zone.c_str());
+    std::string uri_str = butil::string_printf(
+            "/discovery/fetchs?appid=%s&env=%s&status=%s", service_name,
+            FLAGS_discovery_env.c_str(), FLAGS_discovery_status.c_str());
+    if (!FLAGS_discovery_zone.empty()) {
+        uri_str.append("&zone=", 6);
+        uri_str.append(FLAGS_discovery_zone);
+    }
+    cntl.http_request().uri() = uri_str;
     chan->CallMethod(NULL, &cntl, NULL, NULL, NULL);
     if (cntl.Failed()) {
         LOG(ERROR) << "Fail to get /discovery/fetchs: " << cntl.ErrorText();


### PR DESCRIPTION
在使用bili discovery服务发现中，原SDK在fetch nodes没有对服务节点机房做区分，fetch回来的是所有机房的节点，导致多活出现了跨机房调用。

discovery_zone 设置了就会fetch对应的机房节点，不设置默认所有机房节点。