### PR TITLE
bugfix: pid file may be overwritten

### DIFF
--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -1669,7 +1669,7 @@ void Server::PutPidFileIfNeeded() {
             return;
         }
     }
-    int fd = open(_options.pid_file.c_str(), O_WRONLY | O_CREAT, 0666);
+    int fd = open(_options.pid_file.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (fd < 0) {
         LOG(WARNING) << "Fail to open " << _options.pid_file;
         _options.pid_file.clear();


### PR DESCRIPTION
The following step will mess up the pid file:
1. Start the server with pid file enabled. Suppose the pid is 12345.
2. Make the server core dump. 
3. Restart the server. Suppose the new pid is 8888. The pid file will be overwritten with the wrong content 88885.