### PR TITLE
pprof: load symbol when init PProfService

### DIFF
--- a/src/brpc/builtin/pprof_service.cpp
+++ b/src/brpc/builtin/pprof_service.cpp
@@ -517,6 +517,11 @@ static void FindSymbols(butil::IOBuf* out, std::vector<uintptr_t>& addr_list) {
     }
 }
 
+PProfService::PProfService() {
+    // Load /proc/self/maps
+    pthread_once(&s_load_symbolmap_once, LoadSymbols);
+}
+
 void PProfService::symbol(
     ::google::protobuf::RpcController* controller_base,
     const ::brpc::ProfileRequest* /*request*/,
@@ -525,9 +530,6 @@ void PProfService::symbol(
     ClosureGuard done_guard(done);
     Controller* cntl = static_cast<Controller*>(controller_base);
     cntl->http_response().set_content_type("text/plain");
-
-    // Load /proc/self/maps
-    pthread_once(&s_load_symbolmap_once, LoadSymbols);
 
     if (cntl->http_request().method() != HTTP_METHOD_POST) {
         char buf[64];

--- a/src/brpc/builtin/pprof_service.h
+++ b/src/brpc/builtin/pprof_service.h
@@ -25,6 +25,7 @@ namespace brpc {
 
 class PProfService : public pprof {
 public:
+    PProfService();
     void profile(::google::protobuf::RpcController* controller,
                  const ::brpc::ProfileRequest* request,
                  ::brpc::ProfileResponse* response,


### PR DESCRIPTION
We guess it is likely that there is something wrong with this lazy loading symbol map. When process's memory is too large, this operation, which forks 'nm' subprocess several times, will copy a large page table several times. Copy page table holds mm.mmap_sem, which blocks mmap() and brk().