### PR TITLE
Support to compile in mysql by changing LOG_NONE to LOG_TO_NONE

### DIFF
--- a/src/butil/logging.h
+++ b/src/butil/logging.h
@@ -206,7 +206,7 @@ typedef char PathChar;
 // Where to record logging output? A flat file and/or system debug log
 // via OutputDebugString.
 enum LoggingDestination {
-    LOG_NONE                = 0,
+    LOG_TO_NONE                = 0,
     LOG_TO_FILE             = 1 << 0,
     LOG_TO_SYSTEM_DEBUG_LOG = 1 << 1,
 


### PR DESCRIPTION
This pr is for issue #1061.

LOG_NONE is a enum value but it is a macro definition in mysql. This will cause compile error. 

We can solve this problem by changing LOG_NONE to LOG_TO_NONE.