### PR TITLE
add the missing include at bvar/status.h

### DIFF
--- a/src/bvar/status.h
+++ b/src/bvar/status.h
@@ -26,6 +26,7 @@
 #include "butil/string_printf.h"
 #include "butil/synchronization/lock.h"
 #include "bvar/detail/is_atomical.h"
+#include "bvar/reducer.h"
 #include "bvar/variable.h"
 
 namespace bvar {


### PR DESCRIPTION
there is `detail::AddTo` at line 97, which declared in 'bvar/reducer.h'