### PR TITLE
fix redis args

### DIFF
--- a/example/redis_c++/redis_server.cpp
+++ b/example/redis_c++/redis_server.cpp
@@ -66,7 +66,7 @@ public:
 
     brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
-                                        bool flush_batched) override {
+                                        bool /*flush_batched*/) override {
         if (args.size() != 2ul) {
             output->FormatError("Expect 1 arg for 'get', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;
@@ -92,7 +92,7 @@ public:
 
     brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
-                                        bool flush_batched) override {
+                                        bool /*flush_batched*/) override {
         if (args.size() != 3ul) {
             output->FormatError("Expect 2 args for 'set', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;

--- a/example/redis_c++/redis_server.cpp
+++ b/example/redis_c++/redis_server.cpp
@@ -64,18 +64,14 @@ public:
     explicit GetCommandHandler(RedisServiceImpl* rsimpl)
         : _rsimpl(rsimpl) {}
 
-    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args_piece,
+    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
                                         bool flush_batched) override {
-        std::vector<std::string> args;
-        for (size_t i = 0; i < args_piece.size(); ++i) {
-            args.emplace_back(args_piece[i].data(), args_piece.size());
-        }
         if (args.size() != 2ul) {
             output->FormatError("Expect 1 arg for 'get', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;
         }
-        const std::string key(args[1]);
+        const std::string key(args[1].data(), args[1].size());
         std::string value;
         if (_rsimpl->Get(key, &value)) {
             output->SetString(value);
@@ -94,19 +90,15 @@ public:
     explicit SetCommandHandler(RedisServiceImpl* rsimpl)
         : _rsimpl(rsimpl) {}
 
-    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args_piece,
+    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
                                         bool flush_batched) override {
-        std::vector<std::string> args;
-        for (size_t i = 0; i < args_piece.size(); ++i) {
-            args.emplace_back(args_piece[i].data(), args_piece.size());
-        }
         if (args.size() != 3ul) {
             output->FormatError("Expect 2 args for 'set', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;
         }
-        const std::string key(args[1]);
-        const std::string value(args[2]);
+        const std::string key(args[1].data(), args[1].size());
+        const std::string value(args[2].data(), args[2].size());
         _rsimpl->Set(key, value);
         output->SetStatus("OK");
         return brpc::REDIS_CMD_HANDLED;

--- a/example/redis_c++/redis_server.cpp
+++ b/example/redis_c++/redis_server.cpp
@@ -64,9 +64,13 @@ public:
     explicit GetCommandHandler(RedisServiceImpl* rsimpl)
         : _rsimpl(rsimpl) {}
 
-    brpc::RedisCommandHandlerResult Run(const std::vector<const char*>& args,
-                                          brpc::RedisReply* output,
-                                          bool /*flush_batched*/) override {
+    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args_piece,
+                                        brpc::RedisReply* output,
+                                        bool flush_batched) override {
+        std::vector<std::string> args;
+        for (size_t i = 0; i < args_piece.size(); ++i) {
+            args.emplace_back(args_piece[i].data(), args_piece.size());
+        }
         if (args.size() != 2ul) {
             output->FormatError("Expect 1 arg for 'get', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;
@@ -90,9 +94,13 @@ public:
     explicit SetCommandHandler(RedisServiceImpl* rsimpl)
         : _rsimpl(rsimpl) {}
 
-    brpc::RedisCommandHandlerResult Run(const std::vector<const char*>& args,
-                                          brpc::RedisReply* output,
-                                          bool /*flush_batched*/) override {
+    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args_piece,
+                                        brpc::RedisReply* output,
+                                        bool flush_batched) override {
+        std::vector<std::string> args;
+        for (size_t i = 0; i < args_piece.size(); ++i) {
+            args.emplace_back(args_piece[i].data(), args_piece.size());
+        }
         if (args.size() != 3ul) {
             output->FormatError("Expect 2 args for 'set', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -93,7 +93,7 @@ int ConsumeCommand(RedisConnContext* ctx,
         RedisCommandHandler* ch = ctx->redis_service->FindCommandHandler(commands[0].as_string());
         if (!ch) {
             char buf[64];
-            snprintf(buf, sizeof(buf), "ERR unknown command `%s`", commands[0].data());
+            snprintf(buf, sizeof(buf), "ERR unknown command `%s`", commands[0].as_string().c_str());
             output.SetError(buf);
         } else {
             result = ch->Run(commands, &output, flush_batched);

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -189,9 +189,7 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
         wopt.ignore_eovercrowded = true;
         LOG_IF(WARNING, socket->Write(&sendbuf, &wopt) != 0)
             << "Fail to send redis reply";
-        if (err != PARSE_ERROR_NOT_ENOUGH_DATA) {
-            ctx->arena.clear();
-        }
+        ctx->arena.clear();
         return MakeParseError(err);
     } else {
         // NOTE(gejun): PopPipelinedInfo() is actually more contended than what

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -189,7 +189,9 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
         wopt.ignore_eovercrowded = true;
         LOG_IF(WARNING, socket->Write(&sendbuf, &wopt) != 0)
             << "Fail to send redis reply";
-        ctx->arena.clear();
+        if (err != PARSE_ERROR_NOT_ENOUGH_DATA) {
+            ctx->arena.clear();
+        }
         return MakeParseError(err);
     } else {
         // NOTE(gejun): PopPipelinedInfo() is actually more contended than what

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -90,7 +90,7 @@ int ConsumeCommand(RedisConnContext* ctx,
             return -1;
         }
     } else {
-        RedisCommandHandler* ch = ctx->redis_service->FindCommandHandler(commands[0].as_string());
+        RedisCommandHandler* ch = ctx->redis_service->FindCommandHandler(commands[0]);
         if (!ch) {
             char buf[64];
             snprintf(buf, sizeof(buf), "ERR unknown command `%s`", commands[0].as_string().c_str());

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -436,22 +436,20 @@ std::ostream& operator<<(std::ostream& os, const RedisResponse& response) {
     return os;
 }
 
-bool RedisService::AddCommandHandler(const std::string& name, RedisCommandHandler* handler) {
-    butil::StringPiece name_piece(name);
-    auto it = _command_map.find(name_piece);
+bool RedisService::AddCommandHandler(const butil::StringPiece& name, 
+                                     RedisCommandHandler* handler) {
+    std::string lcname = StringToLowerASCII(name.as_string());
+    auto it = _command_map.find(lcname);
     if (it != _command_map.end()) {
         LOG(ERROR) << "redis command name=" << name << " exist";
         return false;
     }
-    
-    _all_commands.push_back(name);
-    name_piece = _all_commands.back();
-    _command_map[name_piece] = handler;
+    _command_map[lcname] = handler;
     return true;
 }
  
 RedisCommandHandler* RedisService::FindCommandHandler(const butil::StringPiece& name) const {
-    auto it = _command_map.find(name);
+    auto it = _command_map.find(name.as_string());
     if (it != _command_map.end()) {
         return it->second;
     }

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -436,9 +436,8 @@ std::ostream& operator<<(std::ostream& os, const RedisResponse& response) {
     return os;
 }
 
-bool RedisService::AddCommandHandler(const butil::StringPiece& name, 
-                                     RedisCommandHandler* handler) {
-    std::string lcname = StringToLowerASCII(name.as_string());
+bool RedisService::AddCommandHandler(const std::string& name, RedisCommandHandler* handler) {
+    std::string lcname = StringToLowerASCII(name);
     auto it = _command_map.find(lcname);
     if (it != _command_map.end()) {
         LOG(ERROR) << "redis command name=" << name << " exist";

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -437,19 +437,21 @@ std::ostream& operator<<(std::ostream& os, const RedisResponse& response) {
 }
 
 bool RedisService::AddCommandHandler(const std::string& name, RedisCommandHandler* handler) {
-    std::string lcname = StringToLowerASCII(name);
-    auto it = _command_map.find(lcname);
+    butil::StringPiece name_piece(name);
+    auto it = _command_map.find(name_piece);
     if (it != _command_map.end()) {
         LOG(ERROR) << "redis command name=" << name << " exist";
         return false;
     }
-    _command_map[lcname] = handler;
+    
+    _all_commands.push_back(name);
+    name_piece = _all_commands.back();
+    _command_map[name_piece] = handler;
     return true;
 }
  
-RedisCommandHandler* RedisService::FindCommandHandler(const std::string& name) const {
-    std::string lcname = StringToLowerASCII(name);
-    auto it = _command_map.find(lcname);
+RedisCommandHandler* RedisService::FindCommandHandler(const butil::StringPiece& name) const {
+    auto it = _command_map.find(name);
     if (it != _command_map.end()) {
         return it->second;
     }

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -222,16 +222,14 @@ public:
     virtual ~RedisService() {}
     
     // Call this function to register `handler` that can handle command `name`.
-    bool AddCommandHandler(const std::string& name, RedisCommandHandler* handler);
+    bool AddCommandHandler(const butil::StringPiece& name, RedisCommandHandler* handler);
 
     // This function should not be touched by user and used by brpc deverloper only.
     RedisCommandHandler* FindCommandHandler(const butil::StringPiece& name) const;
 
 private:
-    typedef BUTIL_HASH_NAMESPACE::hash<butil::StringPiece> StringPieceHasher;
-    typedef std::unordered_map<butil::StringPiece, RedisCommandHandler*, StringPieceHasher> CommandMap;
+    typedef std::unordered_map<std::string, RedisCommandHandler*> CommandMap;
     CommandMap _command_map;
-    std::list<std::string> _all_commands;
 };
 
 enum RedisCommandHandlerResult {

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -222,7 +222,7 @@ public:
     virtual ~RedisService() {}
     
     // Call this function to register `handler` that can handle command `name`.
-    bool AddCommandHandler(const butil::StringPiece& name, RedisCommandHandler* handler);
+    bool AddCommandHandler(const std::string& name, RedisCommandHandler* handler);
 
     // This function should not be touched by user and used by brpc deverloper only.
     RedisCommandHandler* FindCommandHandler(const butil::StringPiece& name) const;

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -22,6 +22,7 @@
 #include <google/protobuf/message.h>
 #include <unordered_map>
 #include <memory>
+#include <list>
 #include "butil/iobuf.h"
 #include "butil/strings/string_piece.h"
 #include "butil/arena.h"
@@ -224,11 +225,13 @@ public:
     bool AddCommandHandler(const std::string& name, RedisCommandHandler* handler);
 
     // This function should not be touched by user and used by brpc deverloper only.
-    RedisCommandHandler* FindCommandHandler(const std::string& name) const;
+    RedisCommandHandler* FindCommandHandler(const butil::StringPiece& name) const;
 
 private:
-    typedef std::unordered_map<std::string, RedisCommandHandler*> CommandMap;
+    typedef BUTIL_HASH_NAMESPACE::hash<butil::StringPiece> StringPieceHasher;
+    typedef std::unordered_map<butil::StringPiece, RedisCommandHandler*, StringPieceHasher> CommandMap;
     CommandMap _command_map;
+    std::list<std::string> _all_commands;
 };
 
 enum RedisCommandHandlerResult {

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -260,7 +260,7 @@ public:
     // an start marker and brpc will call MultiTransactionHandler() to new a transaction
     // handler that all the following commands are sent to this tranction handler until
     // it returns REDIS_CMD_HANDLED. Read the comment below.
-    virtual RedisCommandHandlerResult Run(const std::vector<const char*>& args,
+    virtual RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
                                           brpc::RedisReply* output,
                                           bool flush_batched) = 0;
 

--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -420,7 +420,7 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
     char* d = (char*)arena->allocate((len/8 + 1) * 8);
     buf.cutn(d, len);
     d[len] = '\0';
-    _args[_index] = butil::StringPiece(d, len);
+    _args[_index].set(d, len);
     if (_index == 0) {
         // convert it to lowercase when it is command name
         for (int i = 0; i < len; ++i) {

--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -389,7 +389,7 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
         LOG(ERROR) << '`' << intbuf + 1 << "' is not a valid 64-bit decimal";
         return PARSE_ERROR_ABSOLUTELY_WRONG;
     }
-    if (value <= 0) {
+    if (value < 0) {
         LOG(ERROR) << "Invalid len=" << value << " in redis command";
         return PARSE_ERROR_ABSOLUTELY_WRONG;
     }

--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -362,7 +362,7 @@ RedisCommandParser::RedisCommandParser()
     , _index(0) {}
 
 ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
-                                       std::vector<butil::StringPiece>* commands,
+                                       std::vector<butil::StringPiece>* args,
                                        butil::Arena* arena) {
     const char* pfc = (const char*)buf.fetch1();
     if (pfc == NULL) {
@@ -398,8 +398,8 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
         _parsing_array = true;
         _length = value;
         _index = 0;
-        _commands.resize(value);
-        return Consume(buf, commands, arena);
+        _args.resize(value);
+        return Consume(buf, args, arena);
     }
     CHECK(_index < _length) << "a complete command has been parsed. "
             "impl of RedisCommandParser::Parse is buggy";
@@ -420,7 +420,7 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
     char* d = (char*)arena->allocate((len/8 + 1) * 8);
     buf.cutn(d, len);
     d[len] = '\0';
-    _commands[_index] = butil::StringPiece(d, len);
+    _args[_index] = butil::StringPiece(d, len);
     if (_index == 0) {
         // convert it to lowercase when it is command name
         for (int i = 0; i < len; ++i) {
@@ -434,9 +434,9 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
         return PARSE_ERROR_ABSOLUTELY_WRONG;
     }
     if (++_index < _length) {
-        return Consume(buf, commands, arena);
+        return Consume(buf, args, arena);
     }
-    commands->swap(_commands);
+    args->swap(_args);
     Reset();
     return PARSE_OK;
 }
@@ -445,7 +445,7 @@ void RedisCommandParser::Reset() {
     _parsing_array = false;
     _length = 0;
     _index = 0;
-    _commands.clear();
+    _args.clear();
 }
 
 } // namespace brpc

--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -362,7 +362,7 @@ RedisCommandParser::RedisCommandParser()
     , _index(0) {}
 
 ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
-                                       std::vector<const char*>* commands,
+                                       std::vector<butil::StringPiece>* commands,
                                        butil::Arena* arena) {
     const char* pfc = (const char*)buf.fetch1();
     if (pfc == NULL) {
@@ -420,7 +420,7 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
     char* d = (char*)arena->allocate((len/8 + 1) * 8);
     buf.cutn(d, len);
     d[len] = '\0';
-    _commands[_index] = d;
+    _commands[_index] = butil::StringPiece(d, len);
     if (_index == 0) {
         // convert it to lowercase when it is command name
         for (int i = 0; i < len; ++i) {

--- a/src/brpc/redis_command.h
+++ b/src/brpc/redis_command.h
@@ -48,9 +48,9 @@ public:
     RedisCommandParser();
 
     // Parse raw message from `buf'. Return PARSE_OK and set the parsed command
-    // to `commands' and length to `len' if successful. Memory of commands are
-    // allocated in `arena'.
-    ParseError Consume(butil::IOBuf& buf, std::vector<butil::StringPiece>* commands,
+    // to `args' and length to `len' if successful. Memory of args are allocated 
+    // in `arena'.
+    ParseError Consume(butil::IOBuf& buf, std::vector<butil::StringPiece>* args,
                        butil::Arena* arena);
 
 private:
@@ -60,7 +60,7 @@ private:
     bool _parsing_array;            // if the parser has met array indicator '*'
     int _length;                    // array length
     int _index;                     // current parsing array index
-    std::vector<butil::StringPiece> _commands;  // parsed command string
+    std::vector<butil::StringPiece> _args;  // parsed command string
 };
 
 } // namespace brpc

--- a/src/brpc/redis_command.h
+++ b/src/brpc/redis_command.h
@@ -50,7 +50,7 @@ public:
     // Parse raw message from `buf'. Return PARSE_OK and set the parsed command
     // to `commands' and length to `len' if successful. Memory of commands are
     // allocated in `arena'.
-    ParseError Consume(butil::IOBuf& buf, std::vector<const char*>* commands,
+    ParseError Consume(butil::IOBuf& buf, std::vector<butil::StringPiece>* commands,
                        butil::Arena* arena);
 
 private:
@@ -60,7 +60,7 @@ private:
     bool _parsing_array;            // if the parser has met array indicator '*'
     int _length;                    // array length
     int _index;                     // current parsing array index
-    std::vector<const char*> _commands;  // parsed command string
+    std::vector<butil::StringPiece> _commands;  // parsed command string
 };
 
 } // namespace brpc


### PR DESCRIPTION
1.将const char*替换为butil::StringPiece。当args中包含字符'\0'时，可以知道其真实长度
2.支持长度为0的arg。例如：set key ""，是一个合法的redis请求
