### PR TITLE
For https naming service, use 443 as default port

### DIFF
--- a/src/brpc/global.cpp
+++ b/src/brpc/global.cpp
@@ -115,7 +115,9 @@ const char* const DUMMY_SERVER_PORT_FILE = "dummy_server.port";
 
 struct GlobalExtensions {
     GlobalExtensions()
-        : ch_mh_lb(CONS_HASH_LB_MURMUR3)
+        : dns(80)
+        , dns_with_ssl(443)
+        , ch_mh_lb(CONS_HASH_LB_MURMUR3)
         , ch_md5_lb(CONS_HASH_LB_MD5)
         , ch_ketama_lb(CONS_HASH_LB_KETAMA)
         , constant_cl(0) {
@@ -127,6 +129,7 @@ struct GlobalExtensions {
     FileNamingService fns;
     ListNamingService lns;
     DomainNamingService dns;
+    DomainNamingService dns_with_ssl;
     RemoteFileNamingService rfns;
     ConsulNamingService cns;
     DiscoveryNamingService dcns;
@@ -346,7 +349,7 @@ static void GlobalInitializeOrDieImpl() {
     NamingServiceExtension()->RegisterOrDie("file", &g_ext->fns);
     NamingServiceExtension()->RegisterOrDie("list", &g_ext->lns);
     NamingServiceExtension()->RegisterOrDie("http", &g_ext->dns);
-    NamingServiceExtension()->RegisterOrDie("https", &g_ext->dns);
+    NamingServiceExtension()->RegisterOrDie("https", &g_ext->dns_with_ssl);
     NamingServiceExtension()->RegisterOrDie("redis", &g_ext->dns);
     NamingServiceExtension()->RegisterOrDie("remotefile", &g_ext->rfns);
     NamingServiceExtension()->RegisterOrDie("consul", &g_ext->cns);

--- a/src/brpc/policy/domain_naming_service.cpp
+++ b/src/brpc/policy/domain_naming_service.cpp
@@ -28,7 +28,9 @@
 namespace brpc {
 namespace policy {
 
-DomainNamingService::DomainNamingService() : _aux_buf_len(0) {}
+DomainNamingService::DomainNamingService(int default_port)
+    : _aux_buf_len(0)
+    , _default_port(default_port) {}
 
 int DomainNamingService::GetServers(const char* dns_name,
                                     std::vector<ServerNode>* servers) {
@@ -51,7 +53,7 @@ int DomainNamingService::GetServers(const char* dns_name,
     }
     
     buf[i] = '\0';
-    int port = 80;  // default port of HTTP
+    int port = _default_port;
     if (dns_name[i] == ':') {
         ++i;
         char* end = NULL;
@@ -142,7 +144,7 @@ void DomainNamingService::Describe(
 }
 
 NamingService* DomainNamingService::New() const {
-    return new DomainNamingService;
+    return new DomainNamingService(_default_port);
 }
 
 void DomainNamingService::Destroy() {

--- a/src/brpc/policy/domain_naming_service.h
+++ b/src/brpc/policy/domain_naming_service.h
@@ -28,7 +28,8 @@ namespace policy {
 
 class DomainNamingService : public PeriodicNamingService {
 public:
-    DomainNamingService();
+    DomainNamingService(int default_port);
+    DomainNamingService() : DomainNamingService(80) {}
 
 private:
     int GetServers(const char *service_name,
@@ -43,6 +44,7 @@ private:
 private:
     std::unique_ptr<char[]> _aux_buf;
     size_t _aux_buf_len;
+    int _default_port;
 };
 
 }  // namespace policy


### PR DESCRIPTION
当naming service使用https时，使用443作为默认端口。