### PR TITLE
(FIX COMMENT)butil: remove BasicStringPiece in comments

### DIFF
--- a/src/butil/strings/string_piece.h
+++ b/src/butil/strings/string_piece.h
@@ -155,7 +155,7 @@ BUTIL_EXPORT StringPiece16 substr(const StringPiece16& self,
 
 // Defines the types, methods, operators, and data members common to both
 // StringPiece and StringPiece16. Do not refer to this class directly, but
-// rather to BasicStringPiece, StringPiece, or StringPiece16.
+// rather to StringPiece, or StringPiece16.
 //
 // This is templatized by string class type rather than character type, so
 // BasicStringPiece<std::string> or BasicStringPiece<butil::string16>.


### PR DESCRIPTION
Here may means we don't need to touch `BasicStringPiece` directly. So I removed it here.