### PR TITLE
reduce sampler's mutex scope

### DIFF
--- a/src/bvar/detail/sampler.h
+++ b/src/bvar/detail/sampler.h
@@ -62,7 +62,8 @@ protected:
     virtual ~Sampler();
     
 friend class SamplerCollector;
-    bool _used;
+    // _used indicate whether this sampler is in using.
+    butil::atomic<bool> _used;
     // Sync destroy() and take_sample().
     butil::Mutex _mutex;
 };


### PR DESCRIPTION
Change-Id: I7e413acedc8dfb93eae5c08243f0ff3e484f7059

问题: 线上环境中，进程退出时，hang在sampler->destroy()中的_mutex lock上，持有该_mutex的线程已经不再使用该锁且在正常运行，没有分析出发生路径

改动原因: _used变量无需_mutex保护，减少_mutex的范围来规避该问题。同时stop变量跨越了线程，需要atomic