### PR TITLE
coding style fix in brpc/trackme.cpp

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -146,7 +146,7 @@ void TaskGroup::run_main_task() {
     bvar::PassiveStatus<double> cumulated_cputime(
         get_cumulated_cputime_from_this, this);
     std::unique_ptr<bvar::PerSecond<bvar::PassiveStatus<double> > > usage_bvar;
-    
+
     TaskGroup* dummy = this;
     bthread_t tid;
     while (wait_task(&tid)) {
@@ -169,7 +169,6 @@ void TaskGroup::run_main_task() {
                              (name, &cumulated_cputime, 1));
         }
     }
-    // stop_main_task() was called.
     // Don't forget to add elapse of last wait_task.
     current_task()->stat.cputime_ns += butil::cpuwide_time_ns() - _last_run_ns;
 }
@@ -188,7 +187,7 @@ TaskGroup::TaskGroup(TaskControl* c)
     , _nswitch(0)
     , _last_context_remained(NULL)
     , _last_context_remained_arg(NULL)
-    , _pl(NULL) 
+    , _pl(NULL)
     , _main_stack(NULL)
     , _main_tid(0)
     , _remote_num_nosignal(0)
@@ -275,7 +274,7 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
         // user function is never called, the variables will be unchanged
         // however they'd better reflect failures because the task is stopped
         // abnormally.
-        
+
         // Meta and identifier of the task is persistent in this run.
         TaskMeta* const m = g->_cur_meta;
 
@@ -286,25 +285,25 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
             g->_control->exposed_pending_time() <<
                 (butil::cpuwide_time_ns() - m->cpuwide_start_ns) / 1000L;
         }
-        
+
         // Not catch exceptions except ExitException which is for implementing
-        // bthread_exit(). User code is intended to crash when an exception is 
-        // not caught explicitly. This is consistent with other threading 
+        // bthread_exit(). User code is intended to crash when an exception is
+        // not caught explicitly. This is consistent with other threading
         // libraries.
         void* thread_return;
         try {
             thread_return = m->fn(m->arg);
         } catch (ExitException& e) {
             thread_return = e.value();
-        } 
-        
+        }
+
         // Group is probably changed
         g = tls_task_group;
 
         // TODO: Save thread_return
         (void)thread_return;
 
-        // Logging must be done before returning the keytable, since the logging lib 
+        // Logging must be done before returning the keytable, since the logging lib
         // use bthread local storage internally, or will cause memory leak.
         // FIXME: the time from quiting fn to here is not counted into cputime
         if (m->attr.flags & BTHREAD_LOG_START_AND_FINISH) {
@@ -322,7 +321,7 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
             tls_bls.keytable = NULL;
             m->local_storage.keytable = NULL; // optional
         }
-        
+
         // Increase the version and wake up all joiners, if resulting version
         // is 0, change it to 1 to make bthread_t never be 0. Any access
         // or join to the bthread after changing version will be rejected.
@@ -338,9 +337,9 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
         g->_control->_nbthreads << -1;
         g->set_remained(TaskGroup::_release_last_context, m);
         ending_sched(&g);
-        
+
     } while (g->_cur_meta->tid != g->_main_tid);
-    
+
     // Was called from a pthread and we don't have BTHREAD_STACKTYPE_PTHREAD
     // tasks to run, quit for more tasks.
 }
@@ -591,7 +590,7 @@ void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
         cur_meta->local_storage = tls_bls;
         tls_bls = next_meta->local_storage;
 
-        // Logging must be done after switching the local storage, since the logging lib 
+        // Logging must be done after switching the local storage, since the logging lib
         // use bthread local storage internally, or will cause memory leak.
         if ((cur_meta->attr.flags & BTHREAD_LOG_CONTEXT_SWITCH) ||
             (next_meta->attr.flags & BTHREAD_LOG_CONTEXT_SWITCH)) {
@@ -741,7 +740,7 @@ void TaskGroup::_add_sleep_event(void* void_args) {
     // will be gone.
     SleepArgs e = *static_cast<SleepArgs*>(void_args);
     TaskGroup* g = e.group;
-    
+
     TimerThread::TaskId sleep_id;
     sleep_id = get_global_timer_thread()->schedule(
         ready_to_run_from_timer_thread, void_args,
@@ -752,7 +751,7 @@ void TaskGroup::_add_sleep_event(void* void_args) {
         g->ready_to_run(e.tid);
         return;
     }
-    
+
     // Set TaskMeta::current_sleep which is for interruption.
     const uint32_t given_ver = get_version(e.tid);
     {
@@ -931,7 +930,7 @@ void print_task(std::ostream& os, bthread_t tid) {
            << "\narg=" << (void*)arg
            << "\nattr={stack_type=" << attr.stack_type
            << " flags=" << attr.flags
-           << " keytable_pool=" << attr.keytable_pool 
+           << " keytable_pool=" << attr.keytable_pool
            << "}\nhas_tls=" << has_tls
            << "\nuptime_ns=" << butil::cpuwide_time_ns() - cpuwide_start_ns
            << "\ncputime_ns=" << stat.cputime_ns


### PR DESCRIPTION
1. change the prefix of static global variables from "g_" to "s_" in brpc/trackme.cpp.  
2. delete outdated comments in src/bthread/task_group.cpp.  
3. all other changes  are the trailing spaces.