### PR TITLE
fix coredump cause by bad growth_non_responsive http request

### DIFF
--- a/src/brpc/builtin/hotspots_service.cpp
+++ b/src/brpc/builtin/hotspots_service.cpp
@@ -589,7 +589,6 @@ static void DisplayResult(Controller* cntl,
         }
         break;
     }
-    CHECK(!use_html);
     // NOTE: not send prof_result to os first which does copying.
     os.move_to(resp);
     if (use_html) {


### PR DESCRIPTION
Url from web browser request like 'host:port/hotspots/growth_non_responsive?console=abc' will cause coredump.
ref https://github.com/apache/incubator-brpc/issues/1112