### PR TITLE
Rdma typo

### DIFF
--- a/src/brpc/rdma/README.md
+++ b/src/brpc/rdma/README.md
@@ -1,4 +1,16 @@
-# Using RDMA
+## Compile brpc with RDMA support
+
+To use brpc with RDMA, please make sure you have built brpc with WITH_RDMA option first.
+
+```bash
+
+$ cmake -DWITH_RDMA=on . # in project's directory
+
+$ make -j
+
+```
+
+## Using RDMA
 
 To use rdma, please set the ChannelOptions and ServerOptions like this:
 

--- a/src/brpc/rdma/rdma_communication_manager.cpp
+++ b/src/brpc/rdma/rdma_communication_manager.cpp
@@ -49,9 +49,9 @@ DEFINE_int32(rdma_conn_timeout_ms, 30000,
             "The timeout (ms) for RDMA connection establishment.");
 #endif
 
-static const int FLOW_CONTROL = 1;          // for creating QP
-static const int RETRY_COUNT = 1;           // for creating QP
-static const int RNR_RETRY_COUNT = 0;       // for creating QP
+static const uint8_t FLOW_CONTROL = 1;          // for creating QP
+static const uint8_t RETRY_COUNT = 1;           // for creating QP
+static const uint8_t RNR_RETRY_COUNT = 0;       // for creating QP
 
 RdmaCommunicationManager::RdmaCommunicationManager(void* cm_id)
     : _cm_id(cm_id)

--- a/src/brpc/rdma/rdma_completion_queue.cpp
+++ b/src/brpc/rdma/rdma_completion_queue.cpp
@@ -218,20 +218,20 @@ void RdmaCompletionQueue::CleanUp() {
 
     if (IsRdmaAvailable()) {
         if (cq) {
-			if (cq_channel) {
-				IbvAckCqEvents(cq, _cq_events);
-			}
+            if (cq_channel) {
+                IbvAckCqEvents(cq, _cq_events);
+            }
             if (IbvDestroyCq(cq) < 0) {
                 PLOG(WARNING) << "Fail to destroy rdma cq";
             }
             _cq = NULL;
-			if (cq_channel) {
+            if (cq_channel) {
                 if (IbvDestroyCompChannel(cq_channel) < 0) {
                     PLOG(WARNING) << "Fail to destroy rdma cq channel";
                 }
-				_cq_channel = NULL;
-			}
-		}
+                _cq_channel = NULL;
+            }
+        }
     }
     _cq_events = 0;
     if (_sid > 0) {

--- a/src/brpc/rdma/rdma_endpoint.h
+++ b/src/brpc/rdma/rdma_endpoint.h
@@ -28,7 +28,7 @@
 #include "brpc/socket.h"
 #include "brpc/rdma/rdma_communication_manager.h"
 #include "brpc/rdma/rdma_completion_queue.h"
-#include <brpc/rdma/spsc_queue.h>
+#include "brpc/rdma/spsc_queue.h"
 
 namespace brpc {
 namespace rdma {

--- a/src/brpc/rdma/rdma_traffic_control.cpp
+++ b/src/brpc/rdma/rdma_traffic_control.cpp
@@ -21,8 +21,6 @@ namespace brpc {
 namespace rdma {
 
 extern bool g_rdma_traffic_enabled;
-extern std::vector<brpc::SocketId> g_disabled_conns;
-extern butil::atomic<bool> g_written;
 
 void RdmaTrafficControlServiceImpl::TurnOn(
         google::protobuf::RpcController* cntl_base,

--- a/src/brpc/rdma/spsc_queue.h
+++ b/src/brpc/rdma/spsc_queue.h
@@ -17,7 +17,7 @@
 #ifndef BRPC_RDMA_SPSC_QUEUE_H
 #define BRPC_RDMA_SPSC_QUEUE_H
 
-#include <butil/atomicops.h>
+#include "butil/atomicops.h"
 
 namespace brpc {
 namespace rdma {


### PR DESCRIPTION
Fixed some rdam branch typo issues.

主要修改了一些拼写相关问题，
1、自定义头文件需要使用引号包含；
2、制表符替换为空格统一格式；
3、删除了一些无用的变量；
4、增加了rdma编译说明，以前的编译说明在example的rdma_performance目录下，对新手不太友好；
5、修改一些变量的类型，将int赋值给uint8_t不太友好；
