### PR TITLE
Update atomic_instructions.md

### DIFF
--- a/docs/cn/atomic_instructions.md
+++ b/docs/cn/atomic_instructions.md
@@ -39,7 +39,7 @@
 
 ```c++
 // Thread 1
-// ready was initialized to false
+// bool ready was initialized to false
 p.init();
 ready = true;
 ```
@@ -72,7 +72,7 @@ if (ready) {
 
 ```c++
 // Thread1
-// ready was initialized to false
+// std::atomic<bool> ready was initialized to false
 p.init();
 ready.store(true, std::memory_order_release);
 ```

--- a/docs/en/atomic_instructions.md
+++ b/docs/en/atomic_instructions.md
@@ -39,7 +39,7 @@ For example: the first variable plays the role of switch, controlling accesses t
 
 ```c++
 // Thread 1
-// ready was initialized to false
+// bool ready was initialized to false
 p.init();
 ready = true;
 ```
@@ -72,7 +72,7 @@ Above example can be modified as follows:
 
 ```c++
 // Thread1
-// ready was initialized to false
+// std::atomic<bool> ready was initialized to false
 p.init();
 ready.store(true, std::memory_order_release);
 ```


### PR DESCRIPTION
The member function "operator="  of std::atomic<bool>  is using memory fence "memory_order_seq_cst" (checked msvc142/gcc4.8.2) as default. So the shown error in example 1 will not occur if the type of "ready" is std::atomic<bool> (just the same as it in example 2).
Added a comment to clarify the "ready" in example 1 is "bool", to make sure it make sense.

std::atomic<bool> 的operator= 重载中，默认使用最严格内存序memory_order_seq_cst (查看msvc142/gcc4.8.2)，因此示例1 的问题，在ready是std::atomic<bool>时应该不会出现问题。  如果读者默认示例1和示例2 ready的类型相同（都是std::atomic<bool>），可能存在误解。
因此将示例1中的ready注释为裸bool以确保引发问题
