### PR TITLE
Fixed rdma multi device connect failed issue

### DIFF
--- a/src/brpc/rdma/rdma_communication_manager.cpp
+++ b/src/brpc/rdma/rdma_communication_manager.cpp
@@ -205,6 +205,10 @@ int RdmaCommunicationManager::Connect(char* data, size_t len) {
 }
 
 int RdmaCommunicationManager::BindLocalAddress() {
+#ifndef BRPC_RDMA
+    CHECK(false) << "This should not happen";
+    return -1;
+#else
     sockaddr_in client_sockaddr;
     bzero(&client_sockaddr, sizeof(client_sockaddr));
     client_sockaddr.sin_family = AF_INET;
@@ -215,7 +219,8 @@ int RdmaCommunicationManager::BindLocalAddress() {
         PLOG(WARNING) << "Failed to bind local address";
         return -1;
     }
-    return 0; 
+    return 0;
+#endif
 }
 
 int RdmaCommunicationManager::ResolveAddr(butil::EndPoint& remote_ep) {

--- a/src/brpc/rdma/rdma_communication_manager.cpp
+++ b/src/brpc/rdma/rdma_communication_manager.cpp
@@ -204,6 +204,20 @@ int RdmaCommunicationManager::Connect(char* data, size_t len) {
 #endif
 }
 
+int RdmaCommunicationManager::BindLocalAddress() {
+    sockaddr_in client_sockaddr;
+    bzero(&client_sockaddr, sizeof(client_sockaddr));
+    client_sockaddr.sin_family = AF_INET;
+    client_sockaddr.sin_port = htons(INADDR_ANY);
+    client_sockaddr.sin_addr = GetRdmaIP();
+    int ret = RdmaBindAddr((rdma_cm_id*)_cm_id, (sockaddr *)&client_sockaddr);
+    if (ret != 0) {
+        PLOG(WARNING) << "Failed to bind local address";
+        return -1;
+    }
+    return 0; 
+}
+
 int RdmaCommunicationManager::ResolveAddr(butil::EndPoint& remote_ep) {
 #ifndef BRPC_RDMA
     CHECK(false) << "This should not happen";

--- a/src/brpc/rdma/rdma_communication_manager.h
+++ b/src/brpc/rdma/rdma_communication_manager.h
@@ -82,6 +82,18 @@ public:
     //     -1:  failed, errno set
     int Connect(char* data, size_t len);
 
+    // Bind rdma_cm_id to local address
+    // the rdma_cm_id will be bound to a specified local RDMA device
+    // For client side if we only have one RDMA device or we just want to use the first RDMA device.
+    // We don't not need call this method.
+    // But if we have multi RDMA device, and want to use special device. We need to call this method 
+    // to bind the local address, this funciton will use the --rdma_device GFLAGS specified device ip
+    // address to bind. So you don't need to specified ip address param.
+    // Return:
+    //     0:   success
+    //     -1:  failed, errno set
+    int BindLocalAddress();
+
     // Resolve address
     // Arguments:
     //     remote_ep: the remote endpoint to connect

--- a/src/brpc/rdma/rdma_endpoint.cpp
+++ b/src/brpc/rdma/rdma_endpoint.cpp
@@ -542,6 +542,11 @@ int RdmaEndpoint::HandshakeAtClient(RdmaCMEvent event) {
         if (!_rcm) {
             return -1;
         }
+        // If the client side have multi rdma device
+        // We should bind the cm_id to specified rdma device
+        if (_rcm->BindLocalAddress() < 0) {
+            return -1;
+        }
 
         // Add rdmacm fd to event dispatcher
         if (GetGlobalEventDispatcher(_rcm->GetFD()).


### PR DESCRIPTION
The root cause is that if you specified the rdma_device in GFLAGS, the rdma_helper will alloc the pd in the specified device. But in [RdmaCommunicationManager::Create()](https://github.com/apache/incubator-brpc/blob/rdma/src/brpc/rdma/rdma_communication_manager.cpp#L70) the cm_id will always bind to the first device. So the pd is not matched and create qp will return failed. #1401 