### PR TITLE
Fix build failure on macOS with FlameGraph

### DIFF
--- a/src/brpc/builtin/hotspots_service.cpp
+++ b/src/brpc/builtin/hotspots_service.cpp
@@ -416,11 +416,13 @@ static void DisplayResult(Controller* cntl,
         if (display_type == DisplayType::kUnknown) {
             return cntl->SetFailed(EINVAL, "Invalid display_type=%s", display_type_query->c_str());
         }
+#if defined(OS_LINUX)
         if (display_type == DisplayType::kFlameGraph && !flamegraph_tool) {
             return cntl->SetFailed(EINVAL, "Failed to find environment variable "
                 "FLAMEGRAPH_PL_PATH, please read cpu_profiler doc"
                 "(https://github.com/brpc/brpc/blob/master/docs/cn/cpu_profiler.md)");
         }
+#endif
     }
     if (base_name != NULL) {
         if (!ValidProfilePath(*base_name)) {
@@ -885,11 +887,13 @@ static void StartProfiling(ProfilingType type,
         if (display_type == DisplayType::kUnknown) {
             return cntl->SetFailed(EINVAL, "Invalid display_type=%s", display_type_query->c_str());
         }
+#if defined(OS_LINUX)
         if (display_type == DisplayType::kFlameGraph && !getenv("FLAMEGRAPH_PL_PATH")) {
             return cntl->SetFailed(EINVAL, "Failed to find environment variable "
                 "FLAMEGRAPH_PL_PATH, please read cpu_profiler doc"
                 "(https://github.com/brpc/brpc/blob/master/docs/cn/cpu_profiler.md)");
         }
+#endif
     }
 
     ProfilingClient profiling_client;


### PR DESCRIPTION
kFlameGraph这个变量目前只针对OS_LINUX
但是函数调用的时候，没有加宏保护，导致在macOS下编译失败