### PR TITLE
status文档中的代码示例写错了，需要实现的函数名应为Describe

### DIFF
--- a/docs/cn/status.md
+++ b/docs/cn/status.md
@@ -26,7 +26,7 @@
 class MyService : public XXXService, public brpc::Describable {
 public:
     ...
-    void DescribeStatus(std::ostream& os, const brpc::DescribeOptions& options) const {
+    void Describe(std::ostream& os, const brpc::DescribeOptions& options) const {
         os << "my_status: blahblah";
     }
 };

--- a/docs/en/status.md
+++ b/docs/en/status.md
@@ -26,7 +26,7 @@ Users may customize descriptions on /status by letting the service implement [br
 class MyService : public XXXService, public brpc::Describable {
 public:
     ...
-    void DescribeStatus(std::ostream& os, const brpc::DescribeOptions& options) const {
+    void Describe(std::ostream& os, const brpc::DescribeOptions& options) const {
         os << "my_status: blahblah";
     }
 };


### PR DESCRIPTION
文档中的代码示例写错了，需要实现的函数名应为Describe