### PR TITLE
修改la策略中的异常日志的级别，避免在使用glog的情况下core dump

### DIFF
--- a/src/brpc/policy/locality_aware_load_balancer.cpp
+++ b/src/brpc/policy/locality_aware_load_balancer.cpp
@@ -282,7 +282,7 @@ int LocalityAwareLoadBalancer::SelectServer(const SelectIn& in, SelectOut* out) 
         // falls into infinite loop. This branch should never be entered in
         // production servers. If it does, there must be a bug.
         if (++nloop > 10000) {
-            LOG(FATAL) << "A selection runs too long!";
+            LOG(ERROR) << "A selection runs too long!";
             return EHOSTDOWN;
         }
         


### PR DESCRIPTION
glog的FATAL级别，会触发core dump（glog的设计，不是bug）

在使用glog的情况下，最好不要在服务正常运行的代码中使用FATAL。避免下游异常时，让当前服务直接core掉。