### PR TITLE
SampleRequest写错了应为SampledRequest

### DIFF
--- a/docs/cn/rpc_replay.md
+++ b/docs/cn/rpc_replay.md
@@ -49,7 +49,7 @@ brpc提供了[SampleIterator](https://github.com/brpc/brpc/blob/master/src/brpc/
 #include <brpc/rpc_dump.h>
 ...
 brpc::SampleIterator it("./rpc_data/rpc_dump/echo_server");         
-for (SampleRequest* req = it->Next(); req != NULL; req = it->Next()) {
+for (brpc::SampledRequest* req = it->Next(); req != NULL; req = it->Next()) {
     ...                    
     // req->meta的类型是brpc::RpcDumpMeta，定义在src/brpc/rpc_dump.proto
     // req->request的类型是butil::IOBuf，对应格式说明中的"serialized request"

--- a/src/brpc/rpc_dump.h
+++ b/src/brpc/rpc_dump.h
@@ -75,7 +75,7 @@ inline SampledRequest* AskToBeSampled() {
 // Read samples from dumped files in a directory.
 // Example:
 //   SampleIterator it("./rpc_dump_echo_server");
-//   for (SampleRequest* req = it->Next(); req != NULL; req = it->Next()) {
+//   for (SampledRequest* req = it->Next(); req != NULL; req = it->Next()) {
 //     ...
 //   }
 class SampleIterator {


### PR DESCRIPTION
文档（docs/cn/rpc_replay.md）和注释（src/brpc/rpc_dump.h）中的SampleRequest写错了，应为SampledRequest。

顺便给文档中的SampledRequest套上命名空间。和前后代码风格对齐。