### PR TITLE
修复rpc_replay中ChannelGroup初始化时resize的bug

### DIFF
--- a/tools/rpc_replay/rpc_replay.cpp
+++ b/tools/rpc_replay/rpc_replay.cpp
@@ -77,7 +77,7 @@ int ChannelGroup::Init() {
         max_protocol_size = std::max(max_protocol_size,
                                      (size_t)protocols[i].first);
     }
-    _chans.resize(max_protocol_size);
+    _chans.resize(max_protocol_size + 1);
     for (size_t i = 0; i < protocols.size(); ++i) {
         if (protocols[i].second.support_client() &&
             protocols[i].second.support_server()) {


### PR DESCRIPTION
因为 ChannelGroup 有成员函数channel，是通过传入的ProtocolType当成数组_chans下标使用的。
```cpp
    brpc::Channel* channel(brpc::ProtocolType type) {
        if ((size_t)type < _chans.size()) {
            return _chans[(size_t)type];
        }
        return NULL;
    }
```
而_chans的大小，是如此定义：
```cpp
    for (size_t i = 0; i < protocols.size(); ++i) {
        max_protocol_size = std::max(max_protocol_size,
                                     (size_t)protocols[i].first);
    }
    _chans.resize(max_protocol_size);
```

比如当最大的ProtocolType是26的时候，这个数组的大小是26，但是数组的下标只有0到25，那么是无法通过26找到channel的。

当前因为rpc_replay支持回放的协议类型比较少，所以没出问题。

resize的大小应该是ProtocalType的最大值 + 1