### PR TITLE
消除高版本GCC上编译时大量-Wclass-memaccess的警告

### DIFF
--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -733,7 +733,7 @@ RtmpContext::RtmpContext(const RtmpClientOptions* copt, const Server* server)
     _free_ms_ids.reserve(32);
     CHECK_EQ(0, _mstream_map.init(1024, 70));
     CHECK_EQ(0, _trans_map.init(1024, 70));
-    memset(_cstream_ctx, 0, sizeof(_cstream_ctx));
+    memset(static_cast<void*>(_cstream_ctx), 0, sizeof(_cstream_ctx));
 }
     
 RtmpContext::~RtmpContext() {
@@ -809,7 +809,7 @@ RtmpUnsentMessage::AppendAndDestroySelf(butil::IOBuf* out, Socket* s) {
 }
 
 RtmpContext::SubChunkArray::SubChunkArray() {
-    memset(ptrs, 0, sizeof(ptrs));
+    memset(static_cast<void*>(ptrs), 0, sizeof(ptrs));
 }
 
 RtmpContext::SubChunkArray::~SubChunkArray() {

--- a/src/bthread/fd.cpp
+++ b/src/bthread/fd.cpp
@@ -49,7 +49,7 @@ class LazyArray {
 
 public:
     LazyArray() {
-        memset(_blocks, 0, sizeof(butil::atomic<Block*>) * NBLOCK);
+        memset(static_cast<void*>(_blocks), 0, sizeof(butil::atomic<Block*>) * NBLOCK);
     }
 
     butil::atomic<T>* get_or_new(size_t index) {

--- a/src/butil/object_pool_inl.h
+++ b/src/butil/object_pool_inl.h
@@ -114,7 +114,7 @@ public:
             // We fetch_add nblock in add_block() before setting the entry,
             // thus address_resource() may sees the unset entry. Initialize
             // all entries to NULL makes such address_resource() return NULL.
-            memset(blocks, 0, sizeof(butil::atomic<Block*>) * OP_GROUP_NBLOCK);
+            memset(static_cast<void*>(blocks), 0, sizeof(butil::atomic<Block*>) * OP_GROUP_NBLOCK);
         }
     };
 

--- a/src/butil/resource_pool_inl.h
+++ b/src/butil/resource_pool_inl.h
@@ -130,7 +130,7 @@ public:
             // We fetch_add nblock in add_block() before setting the entry,
             // thus address_resource() may sees the unset entry. Initialize
             // all entries to NULL makes such address_resource() return NULL.
-            memset(blocks, 0, sizeof(butil::atomic<Block*>) * RP_GROUP_NBLOCK);
+            memset(static_cast<void*>(blocks), 0, sizeof(butil::atomic<Block*>) * RP_GROUP_NBLOCK);
         }
     };
 

--- a/src/butil/third_party/rapidjson/document.h
+++ b/src/butil/third_party/rapidjson/document.h
@@ -1661,7 +1661,7 @@ private:
         flags_ = kArrayFlag;
         if (count) {
             data_.a.elements = (GenericValue*)allocator.Malloc(count * sizeof(GenericValue));
-            std::memcpy(data_.a.elements, values, count * sizeof(GenericValue));
+            std::memcpy(static_cast<void*>(data_.a.elements), values, count * sizeof(GenericValue));
         }
         else
             data_.a.elements = NULL;
@@ -1673,7 +1673,7 @@ private:
         flags_ = kObjectFlag;
         if (count) {
             data_.o.members = (Member*)allocator.Malloc(count * sizeof(Member));
-            std::memcpy(data_.o.members, members, count * sizeof(Member));
+            std::memcpy(static_cast<void*>(data_.o.members), members, count * sizeof(Member));
         }
         else
             data_.o.members = NULL;


### PR DESCRIPTION
发现 #1381 这个PR被merge以后，还是有大量`no trivial copy-assignment; use value-initialization instead [-Wclass-memaccess]`的警告。
比如：
```
/home/guodong/github/guodong/incubator-brpc/src/butil/resource_pool.h:97:54:   required from ‘T* butil::get_resource(butil::ResourceId<T>*) [with T = bthread::TimerThread::Task]’
/home/guodong/github/guodong/incubator-brpc/src/bthread/timer_thread.cpp:187:43:   required from here
/home/guodong/github/guodong/incubator-brpc/src/butil/resource_pool_inl.h:133:19: warning: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘class butil::atomic<butil::ResourcePool<bthread::TimerThread::Task>::Block*>’ with no trivial copy-assignment; use value-initialization instead [-Wclass-memaccess]

133 |             memset(blocks, 0, sizeof(butil::atomic<Block*>) * RP_GROUP_NBLOCK);
```

所以我参考 #1381 的修改思路（他参考的rapidjson的中的解决同样告警的PR Tencent/rapidjson#1323 ），将警告的其余各处全部修改了。