### PR TITLE
Implement server eps bvar

### DIFF
--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -283,6 +283,8 @@ void* Server::UpdateDerivedVars(void* arg) {
 
     server->_nerror_bvar.expose_as(prefix, "error");
 
+    server->_eps_bvar.expose_as(prefix, "eps");
+
     bvar::PassiveStatus<timeval> uptime_st(
         prefix, "uptime", GetUptime, (void*)(intptr_t)start_us);
 
@@ -391,6 +393,7 @@ Server::Server(ProfilerLinker)
     , _last_start_time(0)
     , _derivative_thread(INVALID_BTHREAD)
     , _keytable_pool(NULL)
+    , _eps_bvar(&_nerror_bvar)
     , _concurrency(0) {
     BAIDU_CASSERT(offsetof(Server, _concurrency) % 64 == 0,
                   Server_concurrency_must_be_aligned_by_cacheline);

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -679,6 +679,7 @@ friend class Controller;
 
     // mutable is required for `ServerPrivateAccessor' to change this bvar
     mutable bvar::Adder<int64_t> _nerror_bvar;
+    mutable bvar::PerSecond<bvar::Adder<int64_t> > _eps_bvar;
     mutable int32_t BAIDU_CACHELINE_ALIGNMENT _concurrency;
 
 };


### PR DESCRIPTION
Related issue: #1482 
目前brpcz中只有method级别的eps(error_per_second)，本PR实现了server级别的eps。
其实server级别的eps对业务来说更为重要。