### PR TITLE
Fix CheckHealth not set has_request_code

### DIFF
--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -562,7 +562,7 @@ int Channel::CheckHealth() {
         return -1;
     } else {
         SocketUniquePtr tmp_sock;
-        LoadBalancer::SelectIn sel_in = { 0, false, false, 0, NULL };
+        LoadBalancer::SelectIn sel_in = { 0, false, true, 0, NULL };
         LoadBalancer::SelectOut sel_out(&tmp_sock);
         return _lb->SelectServer(sel_in, &sel_out);
     }


### PR DESCRIPTION
loadbalancer：c_murmurhash
当某个下游实例由于某些原因被SetFailed之后，后台会启动一个健康检查线程定时(间隔由参数-health_check_interval控制)检查被屏蔽的实例是否恢复正常。
对于hash类型的loadbalancer，SelectServer(const SelectIn& in, SelectOut* out)函数中的in.has_request_code必须是true，否则会输出错误日志并返回错误(EINVAL)
```c++
if (!in.has_request_code) {
        LOG(ERROR) << "Controller.set_request_code() is required";
        return EINVAL;
}
```

如果下游实例只有几个，在某些情况下，有可能这些实例都被SetFailed了，从而导致后续的所有的请求都会失败。