### PR TITLE
check is valid character in uri

### DIFF
--- a/src/brpc/uri.cpp
+++ b/src/brpc/uri.cpp
@@ -107,14 +107,14 @@ inline const char* SplitHostAndPort(const char* host_begin,
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.4
 // space is not allowed by rfc3986, but allowed by brpc
-static bool is_valid_char(char p) {
+static bool is_valid_char(char c) {
     static const std::unordered_set<char> other_valid_char = {
         ':', '/', '?', '#', '[', ']', '@', '!', '$', '&',
         '\'', '(', ')', '*', '+', ',', ';', '=', '-', '.',
         '_', '~', '%', ' '
     };
 
-    return (isalnum(p) || other_valid_char.count(p));
+    return (isalnum(c) || other_valid_char.count(c));
 }
 
 static bool is_all_spaces(const char* p) {

--- a/src/brpc/uri.cpp
+++ b/src/brpc/uri.cpp
@@ -106,11 +106,12 @@ inline const char* SplitHostAndPort(const char* host_begin,
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.4
+// space is not allowed by rfc3986, but allowed by brpc
 static bool is_valid_char(const char* p) {
     static const std::unordered_set<char> other_valid_char = {
         ':', '/', '?', '#', '[', ']', '@', '!', '$', '&',
         '\'', '(', ')'/ '*', '+', ',', ';', '='/ '-', '.',
-        '_', '~', '%'
+        '_', '~', '%', ' '
     };
 
     return (isalnum(*p) || other_valid_char.find(*p) != other_valid_char.end());

--- a/src/brpc/uri.cpp
+++ b/src/brpc/uri.cpp
@@ -107,14 +107,14 @@ inline const char* SplitHostAndPort(const char* host_begin,
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
 // https://datatracker.ietf.org/doc/html/rfc3986#section-2.4
 // space is not allowed by rfc3986, but allowed by brpc
-static bool is_valid_char(const char* p) {
+static bool is_valid_char(char p) {
     static const std::unordered_set<char> other_valid_char = {
         ':', '/', '?', '#', '[', ']', '@', '!', '$', '&',
         '\'', '(', ')', '*', '+', ',', ';', '=', '-', '.',
         '_', '~', '%', ' '
     };
 
-    return (isalnum(*p) || other_valid_char.find(*p) != other_valid_char.end());
+    return (isalnum(p) || other_valid_char.count(p));
 }
 
 static bool is_all_spaces(const char* p) {
@@ -178,7 +178,7 @@ int URI::SetHttpURL(const char* url) {
         if (action == URI_PARSE_BREAK) {
             break;
         }
-        if (!is_valid_char(p)) {
+        if (!is_valid_char(*p)) {
             _st.set_error(EINVAL, "invalid character in url");
             return -1;
         } else if (*p == ':') {

--- a/src/brpc/uri.cpp
+++ b/src/brpc/uri.cpp
@@ -98,6 +98,10 @@ inline const char* SplitHostAndPort(const char* host_begin,
     return host_end;
 }
 
+static bool is_printable(const char* p) {
+    return (*p > 31 && *p < 127);
+}
+
 static bool is_all_spaces(const char* p) {
     for (; *p == ' '; ++p) {}
     return !*p;
@@ -159,7 +163,10 @@ int URI::SetHttpURL(const char* url) {
         if (action == URI_PARSE_BREAK) {
             break;
         }
-        if (*p == ':') {
+        if (!is_printable(p)) {
+            _st.set_error(EINVAL, "Not printable character in url");
+            return -1;
+        } else if (*p == ':') {
             if (p[1] == '/' && p[2] == '/' && need_scheme) {
                 need_scheme = false;
                 _scheme.assign(start, p - start);

--- a/src/brpc/uri.cpp
+++ b/src/brpc/uri.cpp
@@ -110,7 +110,7 @@ inline const char* SplitHostAndPort(const char* host_begin,
 static bool is_valid_char(const char* p) {
     static const std::unordered_set<char> other_valid_char = {
         ':', '/', '?', '#', '[', ']', '@', '!', '$', '&',
-        '\'', '(', ')'/ '*', '+', ',', ';', '='/ '-', '.',
+        '\'', '(', ')', '*', '+', ',', ';', '=', '-', '.',
         '_', '~', '%', ' '
     };
 

--- a/test/brpc_uri_unittest.cpp
+++ b/test/brpc_uri_unittest.cpp
@@ -488,3 +488,7 @@ TEST(URITest, query_remover_key_value_not_changed_after_modified_query) {
     ASSERT_EQ(qr.value(), "value2");
 }
 
+TEST(URITest, valid_character) {
+    brpc::URI uri;
+    ASSERT_EQ(0, uri.SetHttpURL("www.baidu2.com':/?#[]@!$&()*+,;=-._~%"));
+}


### PR DESCRIPTION
这个PR的目的检查url中是否有不可打印字符。

可打印字符的维基百科：
https://en.wikipedia.org/wiki/ASCII#Printable_characters

之前遇到过一个问题，在调用一个HTTP API接口的时候，要加一个签名字段作为query参数。用openssl计算签名的时候，最后意外多复制了一位，这一位是不可打印的字符。
让后请求接口一直失败，日志打印URL查看也没有问题，因为是不可打印字符，所以无法输出，其实是多了一个隐藏字符。
导致调试了很长时间。



当然可打印的字符中也不是全部都是URL的合法字符，但是其他的非法字符，只要是可打印的都可以很快定位到问题，因此不做考虑。因为判断合法字符的比较繁琐（也容易错漏，引发不必要问题），以下这些都是合法字符：

`A-Z`, `a-z`, `0-9`, `-`, `.`, `_`, `~`, `:`, `/`, `?`, `#`, `[`, `]`, `@`, `!`, `$`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `;`, `%`, `=`

当然如果你们觉得判断是不是合法字符更合适的话，我也可以改成 is_valid 函数。