### PR TITLE
Tanslate getting_started.md into Chinese

### DIFF
--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -1,59 +1,59 @@
-# BUILD
+# 构建
 
-brpc prefers static linkages of deps, so that they don't have to be installed on every machine running the app.
+brpc鼓励静态链接依赖，以便于每个运行brpc服务的机器不必再安装依赖。
 
-brpc depends on following packages:
+brpc有如下依赖：
 
 * [gflags](https://github.com/gflags/gflags): Extensively used to define global options.
 * [protobuf](https://github.com/google/protobuf): Serializations of messages, interfaces of services.
 * [leveldb](https://github.com/google/leveldb): Required by [/rpcz](rpcz.md) to record RPCs for tracing.
 
-# Supported Environment
+# 支持的环境
 
 * [Ubuntu/LinuxMint/WSL](#ubuntulinuxmintwsl)
 * [Fedora/CentOS](#fedoracentos)
-* [Linux with self-built deps](#linux-with-self-built-deps)
+* [自己构建依赖的Linux](#自己构建依赖的Linux)
 * [MacOS](#macos)
 
 ## Ubuntu/LinuxMint/WSL
-### Prepare deps
+### 依赖准备
 
-Install common deps, [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
+安装通用依赖，[gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
 ```shell
 sudo apt-get install -y git g++ make libssl-dev libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev
 ```
 
-If you need to statically link leveldb:
+如果你需要静态链接leveldb：
 ```shell
 sudo apt-get install -y libsnappy-dev
 ```
 
-If you need to enable cpu/heap profilers in examples:
+如果你要在样例中启用cpu/heap的profiler：
 ```shell
 sudo apt-get install -y libgoogle-perftools-dev
 ```
 
-If you need to run tests, install and compile libgtest-dev (which is not compiled yet):
+如果你要运行测试，那么要安装并编译ligtest-dev（它没有被默认编译）：
 ```shell
 sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
 ```
-The directory of gtest source code may be changed, try `/usr/src/googletest/googletest` if `/usr/src/gtest` is not there.
+gtest源码目录可能变动，如果`/usr/src/gtest`不存在，请尝试`/usr/src/googletest/googletest`。
 
-### Compile brpc with config_brpc.sh
-git clone brpc, cd into the repo and run
+### 使用config_brpc.sh编译brpc
+git克隆brpc，进入到项目目录，然后运行
 ```shell
 $ sh config_brpc.sh --headers=/usr/include --libs=/usr/lib
 $ make
 ```
-To change compiler to clang, add `--cxx=clang++ --cc=clang`.
+修改编译器为clang，添加选项`--cxx=clang++ --cc=clang`。
 
-To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+不想链接调试符号，添加选项`--nodebugsymbols`，然后编译将会得到更轻量的二进制文件。
 
-To use brpc with glog, add `--with-glog`.
+使用glog版的brpc，添加选项`--with-glog`。
 
-To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+要启用 [thrift 支持](../en/thrift.md)，首先安装thrift并且添加选项`--with-thrift`。
 
-**Run example**
+**运行样例**
 
 ```shell
 $ cd example/echo_c++
@@ -62,30 +62,30 @@ $ ./echo_server &
 $ ./echo_client
 ```
 
-Examples link brpc statically, if you need to link the shared version, `make clean` and `LINK_SO=1 make`
+上述操作会链接brpc的静态库到样例中，如果你想链接brpc的共享库，请依次执行：`make clean`和`LINK_SO=1 make`
 
-**Run tests**
+**运行测试**
 ```shell
 $ cd test
 $ make
 $ sh run_tests.sh
 ```
 
-### Compile brpc with cmake
+### 使用cmake编译brpc
 ```shell
 cmake -B build && cmake --build build -j6
 ```
-To help VSCode or Emacs(LSP) to understand code correctly, add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to generate `compile_commands.json`
+要帮助VSCode或Emacs(LSP)去正确地理解代码，添加`-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`选项去生成`compile_commands.json`。
 
-To change compiler to clang, overwrite environment variable `CC` and `CXX` to `clang` and `clang++` respectively.
+要修改编译器为clang，请修改环境变量`CC`和`CXX`为`clang`和`clang++`。
 
-To not link debugging symbols, remove `build/CMakeCache.txt` and cmake with `-DWITH_DEBUG_SYMBOLS=OFF`
+不想链接调试符号，请移除`build/CMakeCache.txt`，然后用`-DWITH_DEBUG_SYMBOLS=OFF`选项执行cmake。
 
-To use brpc with glog, cmake with `-DWITH_GLOG=ON`.
+想要让brpc使用glog，用`-DWITH_GLOG=ON`选项执行cmake。
 
-To enable [thrift support](../en/thrift.md), install thrift first and cmake with `-DWITH_THRIFT=ON`.
+要启用 [thrift 支持](../en/thrift.md)，先安装thrift，然后用`-DWITH_THRIFT=ON`选项执行cmake。
 
-**Run example with cmake**
+**用cmake运行样例**
 
 ```shell
 $ cd example/echo_c++
@@ -93,9 +93,10 @@ $ cmake -B build && cmake --build build -j4
 $ ./echo_server &
 $ ./echo_client
 ```
-Examples link brpc statically, if you need to link the shared version, remove `CMakeCache.txt` and cmake with `-DLINK_SO=ON`
 
-**Run tests**
+上述操作会链接brpc的静态库到样例中，如果你想链接brpc的共享库，请先移除`CMakeCache.txt`，然后用`-DLINK_SO=ON`选项重新执行cmake。
+
+**运行测试**
 
 ```shell
 $ mkdir build && cd build && cmake -DBUILD_UNIT_TESTS=ON .. && make && make test
@@ -103,50 +104,50 @@ $ mkdir build && cd build && cmake -DBUILD_UNIT_TESTS=ON .. && make && make test
 
 ## Fedora/CentOS
 
-### Prepare deps
+### 依赖准备
 
-CentOS needs to install EPEL generally otherwise many packages are not available by default.
+CentOS一般需要安装EPEL，否则很多包都默认不可用。
 ```shell
 sudo yum install epel-release
 ```
 
-Install common deps:
+安装通用依赖：
 ```shell
 sudo yum install git gcc-c++ make openssl-devel
 ```
 
-Install [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
+安装 [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
 ```shell
 sudo yum install gflags-devel protobuf-devel protobuf-compiler leveldb-devel
 ```
 
-If you need to enable cpu/heap profilers in examples:
+如果你要在样例中启用cpu/heap的profiler：
 ```shell
 sudo yum install gperftools-devel
 ```
 
-If you need to run tests, install and compile gtest-devel (which is not compiled yet):
+如果你要运行测试，那么要安装ligtest-dev:
 ```shell
 sudo yum install gtest-devel
 ```
 
-### Compile brpc with config_brpc.sh
+### 使用config_brpc.sh编译brpc
 
-git clone brpc, cd into the repo and run
+git克隆brpc，进入项目目录然后执行：
 
 ```shell
 $ sh config_brpc.sh --headers=/usr/include --libs=/usr/lib64
 $ make
 ```
-To change compiler to clang, add `--cxx=clang++ --cc=clang`.
+修改编译器为clang，添加选项`--cxx=clang++ --cc=clang`。
 
-To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+不想链接调试符号，添加选项`--nodebugsymbols` 然后编译将会得到更轻量的二进制文件。
 
-To use brpc with glog, add `--with-glog`.
+想要让brpc使用glog，添加选项：`--with-glog`。
 
-To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+要启用 [thrift 支持](../en/thrift.md)，先安装thrift，然后添加选项：`--with-thrift`。
 
-**Run example**
+**运行样例**
 
 ```shell
 $ cd example/echo_c++
@@ -155,50 +156,50 @@ $ ./echo_server &
 $ ./echo_client
 ```
 
-Examples link brpc statically, if you need to link the shared version, `make clean` and `LINK_SO=1 make`
+上述操作会链接brpc的静态库到样例中，如果你想链接brpc的共享库，请依次执行：`make clean`和`LINK_SO=1 make`
 
-**Run tests**
+**运行测试**
 ```shell
 $ cd test
 $ make
 $ sh run_tests.sh
 ```
 
-### Compile brpc with cmake
-Same with [here](#compile-brpc-with-cmake)
+### 使用cmake编译brpc
+参考[这里](#使用cmake编译brpc)
 
-## Linux with self-built deps
+## 自己构建依赖的Linux
 
-### Prepare deps
+### 依赖准备
 
-brpc builds itself to both static and shared libs by default, so it needs static and shared libs of deps to be built as well.
+brpc默认会构建出静态库和共享库，因此它也需要依赖有静态库和共享库两个版本。
 
-Take [gflags](https://github.com/gflags/gflags) as example, which does not build shared lib by default, you need to pass options to `cmake` to change the behavior:
+以[gflags](https://github.com/gflags/gflags)为例，它默认不够尖共享库，你需要给`cmake`指定选项去改变这一行为：
 ```shell
 $ cmake . -DBUILD_SHARED_LIBS=1 -DBUILD_STATIC_LIBS=1
 $ make
 ```
 
-### Compile brpc
+### 编译brpc
 
-Keep on with the gflags example, let `../gflags_dev` be where gflags is cloned.
+还以gflags为例，`../gflags_dev`表示gflags被克隆的位置。
 
-git clone brpc. cd into the repo and run
+git克隆brpc。进入到项目目录然后运行：
 
 ```shell
 $ sh config_brpc.sh --headers="../gflags_dev /usr/include" --libs="../gflags_dev /usr/lib64"
 $ make
 ```
 
-Here we pass multiple paths to `--headers` and `--libs` to make the script search for multiple places. You can also group all deps and brpc into one directory, then pass the directory to --headers/--libs which actually search all subdirectories recursively and will find necessary files.
+这里我们给`--headers`和`--libs`传递多个路径使得脚本能够在多个地方进行检索。你也可以打包所有依赖和brpc一起放到一个目录中，然后把目录传递给 --headers/--libs选项，它会递归搜索所有子目录直到找到必须的文件。
 
-To change compiler to clang, add `--cxx=clang++ --cc=clang`.
+修改编译器为clang，添加选项`--cxx=clang++ --cc=clang`。
 
-To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+不想链接调试符号，添加选项`--nodebugsymbols`，然后编译将会得到更轻量的二进制文件。
 
-To use brpc with glog, add `--with-glog`.
+使用glog版的brpc，添加选项`--with-glog`。
 
-To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+要启用[thrift 支持](../en/thrift.md)，首先安装thrift并且添加选项`--with-thrift`。
 
 ```shell
 $ ls my_dev
@@ -208,49 +209,49 @@ $ sh config_brpc.sh --headers=.. --libs=..
 $ make
 ```
 
-### Compile brpc with cmake
-Same with [here](#compile-brpc-with-cmake)
+### 使用cmake编译brpc
+参考[这里](#使用cmake编译brpc)
 
 ## MacOS
 
-Note: In the same running environment, the performance of the current Mac version is about 2.5 times worse than the Linux version. If your service is performance-critical, do not use MacOS as your production environment.
+注意：在相同运行环境下，当前Mac版brpc的性能比Linux版差2.5倍。如果你的服务是性能敏感的，请不要使用MacOs作为你的生产环境。
 
-### Prepare deps
+### 依赖准备
 
-Install common deps:
+安装通用依赖：
 ```shell
 brew install openssl git gnu-getopt coreutils
 ```
 
-Install [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
+安装[gflags](https://github.com/gflags/gflags)，[protobuf](https://github.com/google/protobuf)，[ [leveldb](https://github.com/google/leveldb)：
 ```shell
 brew install gflags protobuf leveldb
 ```
 
-If you need to enable cpu/heap profilers in examples:
+如果你要在样例中启用cpu/heap的profiler：
 ```shell
 brew install gperftools
 ```
 
-If you need to run tests, download and compile googletest (which is not compiled yet):
+如果你要运行测试，那么要安装并编译googletest（它没有被默认编译）：
 ```shell
 git clone https://github.com/google/googletest -b release-1.10.0 && cd googletest/googletest && mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-std=c++11" .. && make
 ```
-After the compilation, copy include/ and lib/ into /usr/local/include and /usr/local/lib respectively to expose gtest to all apps
+在编译完成后，复制include/和lib/目录到/usr/local/include和/usr/local/lib目录中，以便于让所有应用都能使用gtest。
 
-### Compile brpc with config_brpc.sh
-git clone brpc, cd into the repo and run
+### 使用config_brpc.sh编译brpc
+git克隆brpc，进入到项目目录然后运行：
 ```shell
 $ sh config_brpc.sh --headers=/usr/local/include --libs=/usr/local/lib --cc=clang --cxx=clang++
 $ make
 ```
-To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+不想链接调试符号，添加选项`--nodebugsymbols`，然后编译将会得到更轻量的二进制文件。
 
-To use brpc with glog, add `--with-glog`.
+使用glog版的brpc，添加选项`--with-glog`。
 
-To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+要启用[thrift 支持](../en/thrift.md)，首先安装thrift并且添加选项`--with-thrift`。
 
-**Run example**
+**运行样例**
 
 ```shell
 $ cd example/echo_c++
@@ -258,85 +259,84 @@ $ make
 $ ./echo_server &
 $ ./echo_client
 ```
+上述操作会链接brpc的静态库到样例中，如果你想链接brpc的共享库，请依次执行：`make clean`和`LINK_SO=1 make`
 
-Examples link brpc statically, if you need to link the shared version, `make clean` and `LINK_SO=1 make`
-
-**Run tests**
+**运行测试**
 ```shell
 $ cd test
 $ make
 $ sh run_tests.sh
 ```
 
-### Compile brpc with cmake
-Same with [here](#compile-brpc-with-cmake)
+### 使用cmake编译brpc
+参考[这里](#使用cmake编译brpc)
 
-# Supported deps
+# 支持的依赖
 
 ## GCC: 4.8-7.1
 
-c++11 is turned on by default to remove dependencies on boost (atomic).
+c++11被默认启用，以去除去boost的依赖（比如atomic）。
 
-The over-aligned issues in GCC7 is suppressed temporarily now.
+GCC7中over-aligned的问题暂时被禁止。
 
-Using other versions of gcc may generate warnings, contact us to fix.
+使用其他版本的gcc可能会产生编译警告，请联系我们予以修复。
 
-Adding `-D__const__=` to cxxflags in your makefiles is a must to avoid [errno issue in gcc4+](thread_local.md).
+请在makefile中给cxxflags增加`-D__const__=`选项以避免[gcc4+中的errno问题](thread_local.md).
 
 ## Clang: 3.5-4.0
 
-no known issues.
+无已知问题。
 
 ## glibc: 2.12-2.25
 
-no known issues.
+无已知问题。
 
 ## protobuf: 2.4+
 
-Be compatible with pb 3.x and pb 2.x with the same file:
-Don't use new types in proto3 and start the proto file with `syntax="proto2";`
-[tools/add_syntax_equal_proto2_to_all.sh](https://github.com/brpc/brpc/blob/master/tools/add_syntax_equal_proto2_to_all.sh)can add `syntax="proto2"` to all proto files without it.
+同一个文件兼容pb 3.x版本和pb 2.x版本：
+不要使用proto3新增的类型，并且在proto文件的起始位置添加`syntax=proto2;`声明。
+[tools/add_syntax_equal_proto2_to_all.sh](https://github.com/brpc/brpc/blob/master/tools/add_syntax_equal_proto2_to_all.sh)这个脚本可以给所有没有这行声明的proto文件添加`syntax="proto2"`声明。
 
-Arena in pb 3.x is not supported yet.
+pb 3.x中的Arena至今没被支持。
 
 ## gflags: 2.0-2.2.1
 
-no known issues.
+无已知问题。
 
 ## openssl: 0.97-1.1
 
-required by https.
+被https功能需要。
 
 ## tcmalloc: 1.7-2.5
 
-brpc does **not** link [tcmalloc](http://goog-perftools.sourceforge.net/doc/tcmalloc.html) by default. Users link tcmalloc on-demand.
+brpc默认**不**链接 [tcmalloc](http://goog-perftools.sourceforge.net/doc/tcmalloc.html)。用户按需要链接tcmalloc。
 
-Comparing to ptmalloc embedded in glibc, tcmalloc often improves performance. However different versions of tcmalloc may behave really differently. For example, tcmalloc 2.1 may make multi-threaded examples in brpc perform significantly worse(due to a spinlock in tcmalloc) than the one using tcmalloc 1.7 and 2.5. Even different minor versions may differ. When you program behave unexpectedly, remove tcmalloc or try another version.
+和glibc内置的ptmalloc相比，tcmalloc通常能提升性能。然而不同版本的tcmalloc可能表现迥异。例如：tcmalloc 2.1与 tcmalloc 1.7和2.5相比，可能会让brpc的多线程样例性能显著恶化（tcmalloc中的一个自旋锁导致的）。甚至不同的小版本号之间变现也可能不同。当你的程序表现不符合预期的时候，移除tcmalloc然后尝试其他版本。
 
-Code compiled with gcc 4.8.2 and linked to a tcmalloc compiled with earlier GCC may crash or deadlock before main(), E.g:
+用gcc4.8.2编译然后链接更早版本GCC编译的tcmalloc，可能会让程序中main()函数之前挂掉或者死锁，例如：
 
 ![img](../images/tcmalloc_stuck.png)
 
-When you meet the issue, compile tcmalloc with the same GCC.
+当你遇到这个问题的时候，请用同一个GCC重新编译tcmalloc。
 
-Another common issue with tcmalloc is that it does not return memory to system as early as ptmalloc. So when there's an invalid memory access, the program may not crash directly, instead it crashes at a unrelated place, or even not crash. When you program has weird memory issues, try removing tcmalloc.
+另外一个使用tcmalloc的常见问题是，它不会像 ptmalloc一样及时地归还内存给系统。因此当有一个无效的内存访问的时候，程序可能不会直接挂掉，取而代之的是它可能在一个不相关的地方挂掉，或者甚至一直不挂掉。当你的程序出现怪异的内存问题的时候，尝试移除tcmalloc。
 
-If you want to use [cpu profiler](cpu_profiler.md) or [heap profiler](heap_profiler.md), do link `libtcmalloc_and_profiler.a`. These two profilers are based on tcmalloc.[contention profiler](contention_profiler.md) does not require tcmalloc.
+如果你要使用[cpu profiler](cpu_profiler.md)或[heap profiler](heap_profiler.md)，要链接`libtcmalloc_and_profiler.a`。这两个 profiler都是基于tcmalloc的。而[contention profiler](contention_profiler.md)不需要tcmalloc。
 
-When you remove tcmalloc, not only remove the linkage with tcmalloc but also the macro `-DBRPC_ENABLE_CPU_PROFILER`.
+当你移除tcmalloc的时候，不仅要移除tcmalloc的链接，也要移除宏`-DBRPC_ENABLE_CPU_PROFILER`。
 
 ## glog: 3.3+
 
-brpc implements a default [logging utility](../../src/butil/logging.h) which conflicts with glog. To replace this with glog, add *--with-glog* to config_brpc.sh or add `-DWITH_GLOG=ON` to cmake.
+brpc实现了一个默认的[日志功能](../../src/butil/logging.h)它和glog冲突。要替换成glog，可以给config_brpc.sh增加*--with-glog*选项或者给cmake增加`-DWITH_GLOG=ON`选项。
 
 ## valgrind: 3.8+
 
-brpc detects valgrind automatically (and registers stacks of bthread). Older valgrind(say 3.2) is not supported.
+brpc会自动检测valgrind（然后注册bthread的栈）。不支持老版本的valgrind（比如3.2）。
 
 ## thrift: 0.9.3-0.11.0
 
-no known issues.
+无已知问题。
 
-# Track instances
+# 实例追踪
 
-We provide a program to help you to track and monitor all brpc instances. Just run [trackme_server](https://github.com/brpc/brpc/tree/master/tools/trackme_server/) somewhere and launch need-to-be-tracked instances with -trackme_server=SERVER. The trackme_server will receive pings from instances periodically and print logs when it does. You can aggregate instance addresses from the log and call builtin services of the instances for further information.
+我们提供了一个程序去帮助你追踪和监控所有brpc实例。 只需要现在某处运行 [trackme_server](https://github.com/brpc/brpc/tree/master/tools/trackme_server/) 然后再带着 -trackme_server=SERVER参数启动需要被追踪的实例。trackme_server将从实例周期性地收到ping消息然后打印日志。您可以从日志中聚合实例地址，并调用实例的内置服务以获取更多信息。

--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -341,4 +341,4 @@ brpc会自动检测valgrind（然后注册bthread的栈）。不支持老版本�
 
 # 实例追踪
 
-我们提供了一个程序去帮助你追踪和监控所有brpc实例。 只需要现在某处运行 [trackme_server](https://github.com/brpc/brpc/tree/master/tools/trackme_server/) 然后再带着 -trackme_server=SERVER参数启动需要被追踪的实例。trackme_server将从实例周期性地收到ping消息然后打印日志。您可以从日志中聚合实例地址，并调用实例的内置服务以获取更多信息。
+我们提供了一个程序去帮助你追踪和监控所有brpc实例。 只需要在某处运行 [trackme_server](https://github.com/brpc/brpc/tree/master/tools/trackme_server/) 然后再带着 -trackme_server=SERVER参数启动需要被追踪的实例。trackme_server将从实例周期性地收到ping消息然后打印日志。您可以从日志中聚合实例地址，并调用实例的内置服务以获取更多信息。

--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -1,3 +1,5 @@
+[English version](../en/getting_started.md)
+
 # 构建
 
 brpc鼓励静态链接依赖，以便于每个运行brpc服务的机器不必再安装依赖。

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -1,0 +1,342 @@
+# BUILD
+
+brpc prefers static linkages of deps, so that they don't have to be installed on every machine running the app.
+
+brpc depends on following packages:
+
+* [gflags](https://github.com/gflags/gflags): Extensively used to define global options.
+* [protobuf](https://github.com/google/protobuf): Serializations of messages, interfaces of services.
+* [leveldb](https://github.com/google/leveldb): Required by [/rpcz](rpcz.md) to record RPCs for tracing.
+
+# Supported Environment
+
+* [Ubuntu/LinuxMint/WSL](#ubuntulinuxmintwsl)
+* [Fedora/CentOS](#fedoracentos)
+* [Linux with self-built deps](#linux-with-self-built-deps)
+* [MacOS](#macos)
+
+## Ubuntu/LinuxMint/WSL
+### Prepare deps
+
+Install common deps, [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
+```shell
+sudo apt-get install -y git g++ make libssl-dev libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev
+```
+
+If you need to statically link leveldb:
+```shell
+sudo apt-get install -y libsnappy-dev
+```
+
+If you need to enable cpu/heap profilers in examples:
+```shell
+sudo apt-get install -y libgoogle-perftools-dev
+```
+
+If you need to run tests, install and compile libgtest-dev (which is not compiled yet):
+```shell
+sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
+```
+The directory of gtest source code may be changed, try `/usr/src/googletest/googletest` if `/usr/src/gtest` is not there.
+
+### Compile brpc with config_brpc.sh
+git clone brpc, cd into the repo and run
+```shell
+$ sh config_brpc.sh --headers=/usr/include --libs=/usr/lib
+$ make
+```
+To change compiler to clang, add `--cxx=clang++ --cc=clang`.
+
+To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+
+To use brpc with glog, add `--with-glog`.
+
+To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+
+**Run example**
+
+```shell
+$ cd example/echo_c++
+$ make
+$ ./echo_server &
+$ ./echo_client
+```
+
+Examples link brpc statically, if you need to link the shared version, `make clean` and `LINK_SO=1 make`
+
+**Run tests**
+```shell
+$ cd test
+$ make
+$ sh run_tests.sh
+```
+
+### Compile brpc with cmake
+```shell
+cmake -B build && cmake --build build -j6
+```
+To help VSCode or Emacs(LSP) to understand code correctly, add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to generate `compile_commands.json`
+
+To change compiler to clang, overwrite environment variable `CC` and `CXX` to `clang` and `clang++` respectively.
+
+To not link debugging symbols, remove `build/CMakeCache.txt` and cmake with `-DWITH_DEBUG_SYMBOLS=OFF`
+
+To use brpc with glog, cmake with `-DWITH_GLOG=ON`.
+
+To enable [thrift support](../en/thrift.md), install thrift first and cmake with `-DWITH_THRIFT=ON`.
+
+**Run example with cmake**
+
+```shell
+$ cd example/echo_c++
+$ cmake -B build && cmake --build build -j4
+$ ./echo_server &
+$ ./echo_client
+```
+Examples link brpc statically, if you need to link the shared version, remove `CMakeCache.txt` and cmake with `-DLINK_SO=ON`
+
+**Run tests**
+
+```shell
+$ mkdir build && cd build && cmake -DBUILD_UNIT_TESTS=ON .. && make && make test
+```
+
+## Fedora/CentOS
+
+### Prepare deps
+
+CentOS needs to install EPEL generally otherwise many packages are not available by default.
+```shell
+sudo yum install epel-release
+```
+
+Install common deps:
+```shell
+sudo yum install git gcc-c++ make openssl-devel
+```
+
+Install [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
+```shell
+sudo yum install gflags-devel protobuf-devel protobuf-compiler leveldb-devel
+```
+
+If you need to enable cpu/heap profilers in examples:
+```shell
+sudo yum install gperftools-devel
+```
+
+If you need to run tests, install and compile gtest-devel (which is not compiled yet):
+```shell
+sudo yum install gtest-devel
+```
+
+### Compile brpc with config_brpc.sh
+
+git clone brpc, cd into the repo and run
+
+```shell
+$ sh config_brpc.sh --headers=/usr/include --libs=/usr/lib64
+$ make
+```
+To change compiler to clang, add `--cxx=clang++ --cc=clang`.
+
+To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+
+To use brpc with glog, add `--with-glog`.
+
+To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+
+**Run example**
+
+```shell
+$ cd example/echo_c++
+$ make
+$ ./echo_server &
+$ ./echo_client
+```
+
+Examples link brpc statically, if you need to link the shared version, `make clean` and `LINK_SO=1 make`
+
+**Run tests**
+```shell
+$ cd test
+$ make
+$ sh run_tests.sh
+```
+
+### Compile brpc with cmake
+Same with [here](#compile-brpc-with-cmake)
+
+## Linux with self-built deps
+
+### Prepare deps
+
+brpc builds itself to both static and shared libs by default, so it needs static and shared libs of deps to be built as well.
+
+Take [gflags](https://github.com/gflags/gflags) as example, which does not build shared lib by default, you need to pass options to `cmake` to change the behavior:
+```shell
+$ cmake . -DBUILD_SHARED_LIBS=1 -DBUILD_STATIC_LIBS=1
+$ make
+```
+
+### Compile brpc
+
+Keep on with the gflags example, let `../gflags_dev` be where gflags is cloned.
+
+git clone brpc. cd into the repo and run
+
+```shell
+$ sh config_brpc.sh --headers="../gflags_dev /usr/include" --libs="../gflags_dev /usr/lib64"
+$ make
+```
+
+Here we pass multiple paths to `--headers` and `--libs` to make the script search for multiple places. You can also group all deps and brpc into one directory, then pass the directory to --headers/--libs which actually search all subdirectories recursively and will find necessary files.
+
+To change compiler to clang, add `--cxx=clang++ --cc=clang`.
+
+To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+
+To use brpc with glog, add `--with-glog`.
+
+To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+
+```shell
+$ ls my_dev
+gflags_dev protobuf_dev leveldb_dev brpc_dev
+$ cd brpc_dev
+$ sh config_brpc.sh --headers=.. --libs=..
+$ make
+```
+
+### Compile brpc with cmake
+Same with [here](#compile-brpc-with-cmake)
+
+## MacOS
+
+Note: In the same running environment, the performance of the current Mac version is about 2.5 times worse than the Linux version. If your service is performance-critical, do not use MacOS as your production environment.
+
+### Prepare deps
+
+Install common deps:
+```shell
+brew install openssl git gnu-getopt coreutils
+```
+
+Install [gflags](https://github.com/gflags/gflags), [protobuf](https://github.com/google/protobuf), [leveldb](https://github.com/google/leveldb):
+```shell
+brew install gflags protobuf leveldb
+```
+
+If you need to enable cpu/heap profilers in examples:
+```shell
+brew install gperftools
+```
+
+If you need to run tests, download and compile googletest (which is not compiled yet):
+```shell
+git clone https://github.com/google/googletest -b release-1.10.0 && cd googletest/googletest && mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-std=c++11" .. && make
+```
+After the compilation, copy include/ and lib/ into /usr/local/include and /usr/local/lib respectively to expose gtest to all apps
+
+### Compile brpc with config_brpc.sh
+git clone brpc, cd into the repo and run
+```shell
+$ sh config_brpc.sh --headers=/usr/local/include --libs=/usr/local/lib --cc=clang --cxx=clang++
+$ make
+```
+To not link debugging symbols, add `--nodebugsymbols` and compiled binaries will be much smaller.
+
+To use brpc with glog, add `--with-glog`.
+
+To enable [thrift support](../en/thrift.md), install thrift first and add `--with-thrift`.
+
+**Run example**
+
+```shell
+$ cd example/echo_c++
+$ make
+$ ./echo_server &
+$ ./echo_client
+```
+
+Examples link brpc statically, if you need to link the shared version, `make clean` and `LINK_SO=1 make`
+
+**Run tests**
+```shell
+$ cd test
+$ make
+$ sh run_tests.sh
+```
+
+### Compile brpc with cmake
+Same with [here](#compile-brpc-with-cmake)
+
+# Supported deps
+
+## GCC: 4.8-7.1
+
+c++11 is turned on by default to remove dependencies on boost (atomic).
+
+The over-aligned issues in GCC7 is suppressed temporarily now.
+
+Using other versions of gcc may generate warnings, contact us to fix.
+
+Adding `-D__const__=` to cxxflags in your makefiles is a must to avoid [errno issue in gcc4+](thread_local.md).
+
+## Clang: 3.5-4.0
+
+no known issues.
+
+## glibc: 2.12-2.25
+
+no known issues.
+
+## protobuf: 2.4+
+
+Be compatible with pb 3.x and pb 2.x with the same file:
+Don't use new types in proto3 and start the proto file with `syntax="proto2";`
+[tools/add_syntax_equal_proto2_to_all.sh](https://github.com/brpc/brpc/blob/master/tools/add_syntax_equal_proto2_to_all.sh)can add `syntax="proto2"` to all proto files without it.
+
+Arena in pb 3.x is not supported yet.
+
+## gflags: 2.0-2.2.1
+
+no known issues.
+
+## openssl: 0.97-1.1
+
+required by https.
+
+## tcmalloc: 1.7-2.5
+
+brpc does **not** link [tcmalloc](http://goog-perftools.sourceforge.net/doc/tcmalloc.html) by default. Users link tcmalloc on-demand.
+
+Comparing to ptmalloc embedded in glibc, tcmalloc often improves performance. However different versions of tcmalloc may behave really differently. For example, tcmalloc 2.1 may make multi-threaded examples in brpc perform significantly worse(due to a spinlock in tcmalloc) than the one using tcmalloc 1.7 and 2.5. Even different minor versions may differ. When you program behave unexpectedly, remove tcmalloc or try another version.
+
+Code compiled with gcc 4.8.2 and linked to a tcmalloc compiled with earlier GCC may crash or deadlock before main(), E.g:
+
+![img](../images/tcmalloc_stuck.png)
+
+When you meet the issue, compile tcmalloc with the same GCC.
+
+Another common issue with tcmalloc is that it does not return memory to system as early as ptmalloc. So when there's an invalid memory access, the program may not crash directly, instead it crashes at a unrelated place, or even not crash. When you program has weird memory issues, try removing tcmalloc.
+
+If you want to use [cpu profiler](cpu_profiler.md) or [heap profiler](heap_profiler.md), do link `libtcmalloc_and_profiler.a`. These two profilers are based on tcmalloc.[contention profiler](contention_profiler.md) does not require tcmalloc.
+
+When you remove tcmalloc, not only remove the linkage with tcmalloc but also the macro `-DBRPC_ENABLE_CPU_PROFILER`.
+
+## glog: 3.3+
+
+brpc implements a default [logging utility](../../src/butil/logging.h) which conflicts with glog. To replace this with glog, add *--with-glog* to config_brpc.sh or add `-DWITH_GLOG=ON` to cmake.
+
+## valgrind: 3.8+
+
+brpc detects valgrind automatically (and registers stacks of bthread). Older valgrind(say 3.2) is not supported.
+
+## thrift: 0.9.3-0.11.0
+
+no known issues.
+
+# Track instances
+
+We provide a program to help you to track and monitor all brpc instances. Just run [trackme_server](https://github.com/brpc/brpc/tree/master/tools/trackme_server/) somewhere and launch need-to-be-tracked instances with -trackme_server=SERVER. The trackme_server will receive pings from instances periodically and print logs when it does. You can aggregate instance addresses from the log and call builtin services of the instances for further information.

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -1,3 +1,5 @@
+[中文版](../cn/getting_started.md)
+
 # BUILD
 
 brpc prefers static linkages of deps, so that they don't have to be installed on every machine running the app.

--- a/docs/en/thrift.md
+++ b/docs/en/thrift.md
@@ -35,7 +35,7 @@ sh config_brpc.sh --headers=/usr/include --libs=/usr/lib64 --with-thrift
 # Or use cmake
 mkdir build && cd build && cmake ../ -DWITH_THRIFT=ON
 ```
-Read [Getting Started](../cn/getting_started.md) for more compilation options.
+Read [Getting Started](getting_started.md) for more compilation options.
 
 # Client accesses thrift server
 Steps：


### PR DESCRIPTION
- tanslate cn/getting_started.md into Chinese.
- move origin getting_started.md to docs/en.
- docs/en/thrift.md reference en/getting_started.md.

原先 docs/cn目录下放的 getting_started.md 是英文的。这个目录应该放中文的才对。
转移到了en目录下，然后对cn目录中的该文件做了一下翻译。