### PR TITLE
Set hostname rather than ip when channel Init by hostname but not host in http_requst().uri()

### DIFF
--- a/docs/cn/http_client.md
+++ b/docs/cn/http_client.md
@@ -114,7 +114,7 @@ URL的一般形式如下图：
 
 若用户没有填且URL中包含host，比如http://www.foo.com/path，则http request中会包含"Host: www.foo.com"。
 
-若用户没有填且URL不包含host，比如"/index.html?name=value"，但如果Channel初始化的地址包含域名，则框架会以域名作为Host，比如"http://www.foo.com"，该http server将会看到"Host: www.foo.com"。如果地址是"http://www.foo.com:8989"，则该http server将会看到"Host: www.foo.com"。
+若用户没有填且URL不包含host，比如"/index.html?name=value"，但如果Channel初始化的地址包含域名，则框架会以域名作为Host，比如"http://www.foo.com"，该http server将会看到"Host: www.foo.com"。如果地址是"http://www.foo.com:8989"，则该http server将会看到"Host: www.foo.com:8989"。
 
 若用户没有填且URL不包含host，比如"/index.html?name=value"，如果Channel初始化的地址也不包含域名，则框架会以目标server的ip和port为Host，地址为10.46.188.39:8989的http server将会看到"Host: 10.46.188.39:8989"。
 

--- a/docs/cn/http_client.md
+++ b/docs/cn/http_client.md
@@ -114,7 +114,9 @@ URL的一般形式如下图：
 
 若用户没有填且URL中包含host，比如http://www.foo.com/path，则http request中会包含"Host: www.foo.com"。
 
-若用户没有填且URL不包含host，比如"/index.html?name=value"，则框架会以目标server的ip和port为Host，地址为10.46.188.39:8989的http server将会看到"Host: 10.46.188.39:8989"。
+若用户没有填且URL不包含host，比如"/index.html?name=value"，但如果Channel初始化的地址包含域名，则框架会以域名和port作为Host，比如"http://www.foo.com"，该http server将会看到"Host: www.foo.com:80"。如果地址是"http://www.foo.com:8989"，则该http server将会看到"Host: www.foo.com:8989"。
+
+若用户没有填且URL不包含host，比如"/index.html?name=value"，如果Channel初始化的地址也不包含域名，则框架会以目标server的ip和port为Host，地址为10.46.188.39:8989的http server将会看到"Host: 10.46.188.39:8989"。
 
 对应的字段在h2中叫":authority"。
 

--- a/docs/cn/http_client.md
+++ b/docs/cn/http_client.md
@@ -114,7 +114,7 @@ URL的一般形式如下图：
 
 若用户没有填且URL中包含host，比如http://www.foo.com/path，则http request中会包含"Host: www.foo.com"。
 
-若用户没有填且URL不包含host，比如"/index.html?name=value"，但如果Channel初始化的地址包含域名，则框架会以域名和port作为Host，比如"http://www.foo.com"，该http server将会看到"Host: www.foo.com:80"。如果地址是"http://www.foo.com:8989"，则该http server将会看到"Host: www.foo.com:8989"。
+若用户没有填且URL不包含host，比如"/index.html?name=value"，但如果Channel初始化的地址包含域名，则框架会以域名作为Host，比如"http://www.foo.com"，该http server将会看到"Host: www.foo.com"。如果地址是"http://www.foo.com:8989"，则该http server将会看到"Host: www.foo.com"。
 
 若用户没有填且URL不包含host，比如"/index.html?name=value"，如果Channel初始化的地址也不包含域名，则框架会以目标server的ip和port为Host，地址为10.46.188.39:8989的http server将会看到"Host: 10.46.188.39:8989"。
 

--- a/docs/en/http_client.md
+++ b/docs/en/http_client.md
@@ -115,7 +115,9 @@ If user already sets `Host` header(case insensitive), framework makes no change.
 
 If user does not set `Host` header and the URL has host, for example http://www.foo.com/path, the http request contains "Host: www.foo.com".
 
-If user does not set host header and the URL does not have host as well,  for example "/index.html?name=value", framework sets `Host` header with IP and port of the target server. A http server at 10.46.188.39:8989 should see `Host: 10.46.188.39:8989`.
+If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name and port of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com:80`. if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com:8989`.
+
+If user does not set host header and the URL does not have host as well,  for example "/index.html?name=value", and the address initialized by the channel doesn't contain domain name. framework sets `Host` header with IP and port of the target server. A http server at 10.46.188.39:8989 should see `Host: 10.46.188.39:8989`.
 
 The header is named ":authority" in h2.
 

--- a/docs/en/http_client.md
+++ b/docs/en/http_client.md
@@ -115,7 +115,7 @@ If user already sets `Host` header(case insensitive), framework makes no change.
 
 If user does not set `Host` header and the URL has host, for example http://www.foo.com/path, the http request contains "Host: www.foo.com".
 
-If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name and port of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com:80`. if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com:8989`.
+If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com`. if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com`.
 
 If user does not set host header and the URL does not have host as well,  for example "/index.html?name=value", and the address initialized by the channel doesn't contain domain name. framework sets `Host` header with IP and port of the target server. A http server at 10.46.188.39:8989 should see `Host: 10.46.188.39:8989`.
 

--- a/docs/en/http_client.md
+++ b/docs/en/http_client.md
@@ -115,7 +115,7 @@ If user already sets `Host` header(case insensitive), framework makes no change.
 
 If user does not set `Host` header and the URL has host, for example http://www.foo.com/path, the http request contains "Host: www.foo.com".
 
-If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com`, if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com`.
+If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com`, if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com:8989`.
 
 If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", and the address initialized by the channel doesn't contain domain name. framework sets `Host` header with IP and port of the target server. A http server at 10.46.188.39:8989 should see `Host: 10.46.188.39:8989`.
 

--- a/docs/en/http_client.md
+++ b/docs/en/http_client.md
@@ -115,9 +115,9 @@ If user already sets `Host` header(case insensitive), framework makes no change.
 
 If user does not set `Host` header and the URL has host, for example http://www.foo.com/path, the http request contains "Host: www.foo.com".
 
-If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com`. if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com`.
+If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", but if the address initialized by the channel contains domain name. framework sets `Host` header with domain name of the target server. if this address is "http://www.foo.com", this http server should see `Host: www.foo.com`, if this address is "http://www.foo.com:8989", this http server should be see `Host: www.foo.com`.
 
-If user does not set host header and the URL does not have host as well,  for example "/index.html?name=value", and the address initialized by the channel doesn't contain domain name. framework sets `Host` header with IP and port of the target server. A http server at 10.46.188.39:8989 should see `Host: 10.46.188.39:8989`.
+If user does not set host header and the URL does not have host as well, for example "/index.html?name=value", and the address initialized by the channel doesn't contain domain name. framework sets `Host` header with IP and port of the target server. A http server at 10.46.188.39:8989 should see `Host: 10.46.188.39:8989`.
 
 The header is named ":authority" in h2.
 

--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -333,7 +333,9 @@ int Channel::Init(const char* ns_url,
                      NULL, &_options.mutable_ssl_options()->sni_name, NULL);
         }
     }
-    ParseHostname(ns_url);
+    if (_options.protocol == brpc::PROTOCOL_HTTP) {
+        ParseHostname(ns_url);
+    }
     LoadBalancerWithNaming* lb = new (std::nothrow) LoadBalancerWithNaming;
     if (NULL == lb) {
         LOG(FATAL) << "Fail to new LoadBalancerWithNaming";
@@ -576,16 +578,14 @@ int Channel::CheckHealth() {
     }
 }
 
-int Channel::ParseHostname(const char* server_addr) {
+void Channel::ParseHostname(const char* server_addr) {
     std::string host;
     if (ParseURL(server_addr, NULL, &host, NULL) == 0) {
         butil::ip_t ip;
         if (butil::hostname2ip(host.c_str(), &ip) == 0) {
             _hostname.swap(host);
-            return 0;
         }
     }
-    return -1;
 }
 
 } // namespace brpc

--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -288,14 +288,13 @@ int Channel::InitSingle(const butil::EndPoint& server_addr_and_port,
     if (InitChannelOptions(options) != 0) {
         return -1;
     }
-    if (_options.protocol == brpc::PROTOCOL_HTTP &&
-        ::strncmp(raw_server_address, "https://", 8) == 0) {
+    std::string scheme;
+    ParseURL(raw_server_address, &scheme, &_service_name, NULL);
+    if (_options.protocol == brpc::PROTOCOL_HTTP && scheme == "https://") {
         if (_options.mutable_ssl_options()->sni_name.empty()) {
-            ParseURL(raw_server_address,
-                     NULL, &_options.mutable_ssl_options()->sni_name, NULL);
+            _options.mutable_ssl_options()->sni_name = _service_name;
         }
     }
-    ParseURL(raw_server_address, NULL, &_service_name, NULL);
     const int port = server_addr_and_port.port;
     if (port < 0 || port > 65535) {
         LOG(ERROR) << "Invalid port=" << port;
@@ -326,14 +325,13 @@ int Channel::Init(const char* ns_url,
     if (InitChannelOptions(options) != 0) {
         return -1;
     }
-    if (_options.protocol == brpc::PROTOCOL_HTTP &&
-        ::strncmp(ns_url, "https://", 8) == 0) {
+    std::string scheme;
+    ParseURL(ns_url, &scheme, &_service_name, NULL);
+    if (_options.protocol == brpc::PROTOCOL_HTTP && scheme == "https://") {
         if (_options.mutable_ssl_options()->sni_name.empty()) {
-            ParseURL(ns_url,
-                     NULL, &_options.mutable_ssl_options()->sni_name, NULL);
+            _options.mutable_ssl_options()->sni_name = _service_name;
         }
     }
-    ParseURL(ns_url, NULL, &_service_name, NULL);
     LoadBalancerWithNaming* lb = new (std::nothrow) LoadBalancerWithNaming;
     if (NULL == lb) {
         LOG(FATAL) << "Fail to new LoadBalancerWithNaming";

--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -295,7 +295,7 @@ int Channel::InitSingle(const butil::EndPoint& server_addr_and_port,
                      NULL, &_options.mutable_ssl_options()->sni_name, NULL);
         }
     }
-    ParseServiceName(raw_server_address);
+    ParseURL(raw_server_address, NULL, &_service_name, NULL);
     const int port = server_addr_and_port.port;
     if (port < 0 || port > 65535) {
         LOG(ERROR) << "Invalid port=" << port;
@@ -333,7 +333,7 @@ int Channel::Init(const char* ns_url,
                      NULL, &_options.mutable_ssl_options()->sni_name, NULL);
         }
     }
-    ParseServiceName(ns_url);
+    ParseURL(ns_url, NULL, &_service_name, NULL);
     LoadBalancerWithNaming* lb = new (std::nothrow) LoadBalancerWithNaming;
     if (NULL == lb) {
         LOG(FATAL) << "Fail to new LoadBalancerWithNaming";
@@ -573,12 +573,6 @@ int Channel::CheckHealth() {
         LoadBalancer::SelectIn sel_in = { 0, false, false, 0, NULL };
         LoadBalancer::SelectOut sel_out(&tmp_sock);
         return _lb->SelectServer(sel_in, &sel_out);
-    }
-}
-
-void Channel::ParseServiceName(const char* server_addr) {
-    if (ParseURL(server_addr, NULL, &_service_name, NULL) != 0) {
-        _service_name.clear();
     }
 }
 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -200,6 +200,8 @@ public:
 protected:
     int CheckHealth();
 
+    int ParseHostname(const char* server_addr);
+
     bool SingleServer() const { return _lb.get() == NULL; }
 
     // Pick a server using `lb' and then send RPC. Wait for response when 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -213,9 +213,9 @@ protected:
     int InitChannelOptions(const ChannelOptions* options);
     int InitSingle(const butil::EndPoint& server_addr_and_port,
                    const char* raw_server_address,
-                   const ChannelOptions* options);
+                   const ChannelOptions* options,
+                   int raw_port = -1);
 
-    // May be ip, hostname or name_service
     std::string _service_name;
     butil::EndPoint _server_address;
     SocketId _server_id;

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -200,7 +200,7 @@ public:
 protected:
     int CheckHealth();
 
-    int ParseHostname(const char* server_addr);
+    void ParseHostname(const char* server_addr);
 
     bool SingleServer() const { return _lb.get() == NULL; }
 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -200,8 +200,6 @@ public:
 protected:
     int CheckHealth();
 
-    void ParseServiceName(const char* server_addr);
-
     bool SingleServer() const { return _lb.get() == NULL; }
 
     // Pick a server using `lb' and then send RPC. Wait for response when 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -200,7 +200,7 @@ public:
 protected:
     int CheckHealth();
 
-    void ParseHostname(const char* server_addr);
+    void ParseServiceName(const char* server_addr);
 
     bool SingleServer() const { return _lb.get() == NULL; }
 
@@ -217,7 +217,8 @@ protected:
                    const char* raw_server_address,
                    const ChannelOptions* options);
 
-    std::string _hostname;
+    // May be ip, hostname or name_service
+    std::string _service_name;
     butil::EndPoint _server_address;
     SocketId _server_id;
     Protocol::SerializeRequest _serialize_request;

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -215,6 +215,7 @@ protected:
                    const char* raw_server_address,
                    const ChannelOptions* options);
 
+    std::string _hostname;
     butil::EndPoint _server_address;
     SocketId _server_id;
     Protocol::SerializeRequest _serialize_request;

--- a/src/brpc/details/http_message.cpp
+++ b/src/brpc/details/http_message.cpp
@@ -567,6 +567,8 @@ void MakeRawHttpRequest(butil::IOBuf* request,
             os << uri.host();
             if (uri.port() >= 0) {
                 os << ':' << uri.port();
+            } else if (remote_side.port != 0) {
+                os << ':' << remote_side.port;
             }
         } else if (remote_side.port != 0) {
             os << remote_side;

--- a/src/brpc/details/http_message.cpp
+++ b/src/brpc/details/http_message.cpp
@@ -567,8 +567,6 @@ void MakeRawHttpRequest(butil::IOBuf* request,
             os << uri.host();
             if (uri.port() >= 0) {
                 os << ':' << uri.port();
-            } else if (remote_side.port != 0) {
-                os << ':' << remote_side.port;
             }
         } else if (remote_side.port != 0) {
             os << remote_side;

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -1958,6 +1958,42 @@ TEST_F(ChannelTest, init_using_naming_service) {
     // `lb' should be destroyed after
 }
 
+TEST_F(ChannelTest, parse_hostname) {
+    brpc::ChannelOptions opt;
+    opt.succeed_without_server = false;
+    brpc::Channel channel;
+
+    ASSERT_EQ(-1, channel.Init("", 8888, &opt));
+    ASSERT_EQ("", channel._hostname);
+    ASSERT_EQ(-1, channel.Init("", &opt));
+    ASSERT_EQ("", channel._hostname);
+
+    ASSERT_EQ(0, channel.Init("127.0.0.1", 8888, &opt));
+    ASSERT_EQ("127.0.0.1", channel._hostname);
+    ASSERT_EQ(0, channel.Init("127.0.0.1:8888", &opt));
+    ASSERT_EQ("127.0.0.1", channel._hostname);
+
+    ASSERT_EQ(0, channel.Init("localhost", 8888, &opt));
+    ASSERT_EQ("localhost", channel._hostname);
+    ASSERT_EQ(0, channel.Init("localhost:8888", &opt));
+    ASSERT_EQ("localhost", channel._hostname);
+
+    opt.protocol = brpc::PROTOCOL_HTTP;
+    ASSERT_EQ(0, channel.Init("http://baidu.com", &opt));
+    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ(0, channel.Init("http://baidu.com", 80, &opt));
+    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ(0, channel.Init("https://baidu.com", &opt));
+    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ(0, channel.Init("https://baidu.com", 443, &opt));
+    ASSERT_EQ("baidu.com", channel._hostname);
+
+    ASSERT_EQ(0, channel.Init("http://baidu.com", "rr", &opt));
+    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ(0, channel.Init("https://baidu.com", "rr", &opt));
+    ASSERT_EQ("baidu.com", channel._hostname);
+}
+
 TEST_F(ChannelTest, connection_failed) {
     for (int i = 0; i <= 1; ++i) { // Flag SingleServer 
         for (int j = 0; j <= 1; ++j) { // Flag Asynchronous

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -1964,34 +1964,54 @@ TEST_F(ChannelTest, parse_hostname) {
     brpc::Channel channel;
 
     ASSERT_EQ(-1, channel.Init("", 8888, &opt));
-    ASSERT_EQ("", channel._hostname);
+    ASSERT_EQ("", channel._service_name);
     ASSERT_EQ(-1, channel.Init("", &opt));
-    ASSERT_EQ("", channel._hostname);
+    ASSERT_EQ("", channel._service_name);
 
     ASSERT_EQ(0, channel.Init("127.0.0.1", 8888, &opt));
-    ASSERT_EQ("127.0.0.1", channel._hostname);
+    ASSERT_EQ("127.0.0.1", channel._service_name);
     ASSERT_EQ(0, channel.Init("127.0.0.1:8888", &opt));
-    ASSERT_EQ("127.0.0.1", channel._hostname);
+    ASSERT_EQ("127.0.0.1", channel._service_name);
 
     ASSERT_EQ(0, channel.Init("localhost", 8888, &opt));
-    ASSERT_EQ("localhost", channel._hostname);
+    ASSERT_EQ("localhost", channel._service_name);
     ASSERT_EQ(0, channel.Init("localhost:8888", &opt));
-    ASSERT_EQ("localhost", channel._hostname);
+    ASSERT_EQ("localhost", channel._service_name);
 
     opt.protocol = brpc::PROTOCOL_HTTP;
     ASSERT_EQ(0, channel.Init("http://baidu.com", &opt));
-    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ("baidu.com", channel._service_name);
     ASSERT_EQ(0, channel.Init("http://baidu.com", 80, &opt));
-    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ("baidu.com", channel._service_name);
     ASSERT_EQ(0, channel.Init("https://baidu.com", &opt));
-    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ("baidu.com", channel._service_name);
     ASSERT_EQ(0, channel.Init("https://baidu.com", 443, &opt));
-    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ("baidu.com", channel._service_name);
 
     ASSERT_EQ(0, channel.Init("http://baidu.com", "rr", &opt));
-    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ("baidu.com", channel._service_name);
     ASSERT_EQ(0, channel.Init("https://baidu.com", "rr", &opt));
-    ASSERT_EQ("baidu.com", channel._hostname);
+    ASSERT_EQ("baidu.com", channel._service_name);
+
+    const char *address_list[] =  {
+        "10.127.0.1:1234",
+        "10.128.0.1:1234 enable",
+        "10.129.0.1:1234",
+        "localhost:1234",
+        "baidu.com:1234"
+    };
+    butil::TempFile tmp_file;
+    {
+        FILE* fp = fopen(tmp_file.fname(), "w");
+        for (size_t i = 0; i < ARRAY_SIZE(address_list); ++i) {
+            ASSERT_TRUE(fprintf(fp, "%s\n", address_list[i]));
+        }
+        fclose(fp);
+    }
+    brpc::Channel ns_channel;
+    std::string ns = std::string("file://") + tmp_file.fname();
+    ASSERT_EQ(0, ns_channel.Init(ns.c_str(), "rr", &opt));
+    ASSERT_EQ(tmp_file.fname(), ns_channel._service_name);
 }
 
 TEST_F(ChannelTest, connection_failed) {

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -1961,6 +1961,7 @@ TEST_F(ChannelTest, init_using_naming_service) {
 TEST_F(ChannelTest, parse_hostname) {
     brpc::ChannelOptions opt;
     opt.succeed_without_server = false;
+    opt.protocol = brpc::PROTOCOL_HTTP;
     brpc::Channel channel;
 
     ASSERT_EQ(-1, channel.Init("", 8888, &opt));
@@ -1968,30 +1969,49 @@ TEST_F(ChannelTest, parse_hostname) {
     ASSERT_EQ(-1, channel.Init("", &opt));
     ASSERT_EQ("", channel._service_name);
 
-    ASSERT_EQ(0, channel.Init("127.0.0.1", 8888, &opt));
-    ASSERT_EQ("127.0.0.1", channel._service_name);
-    ASSERT_EQ(0, channel.Init("127.0.0.1:8888", &opt));
-    ASSERT_EQ("127.0.0.1", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://127.0.0.1", 8888, &opt));
+    ASSERT_EQ("127.0.0.1:8888", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://127.0.0.1:8888", &opt));
+    ASSERT_EQ("127.0.0.1:8888", channel._service_name);
 
     ASSERT_EQ(0, channel.Init("localhost", 8888, &opt));
-    ASSERT_EQ("localhost", channel._service_name);
+    ASSERT_EQ("localhost:8888", channel._service_name);
     ASSERT_EQ(0, channel.Init("localhost:8888", &opt));
-    ASSERT_EQ("localhost", channel._service_name);
+    ASSERT_EQ("localhost:8888", channel._service_name);
 
-    opt.protocol = brpc::PROTOCOL_HTTP;
     ASSERT_EQ(0, channel.Init("http://baidu.com", &opt));
     ASSERT_EQ("baidu.com", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://baidu.com:80", &opt));
+    ASSERT_EQ("baidu.com:80", channel._service_name);
     ASSERT_EQ(0, channel.Init("http://baidu.com", 80, &opt));
-    ASSERT_EQ("baidu.com", channel._service_name);
-    ASSERT_EQ(0, channel.Init("https://baidu.com", &opt));
-    ASSERT_EQ("baidu.com", channel._service_name);
-    ASSERT_EQ(0, channel.Init("https://baidu.com", 443, &opt));
-    ASSERT_EQ("baidu.com", channel._service_name);
-
+    ASSERT_EQ("baidu.com:80", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://baidu.com:8888", &opt));
+    ASSERT_EQ("baidu.com:8888", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://baidu.com", 8888, &opt));
+    ASSERT_EQ("baidu.com:8888", channel._service_name);
     ASSERT_EQ(0, channel.Init("http://baidu.com", "rr", &opt));
     ASSERT_EQ("baidu.com", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://baidu.com:80", "rr", &opt));
+    ASSERT_EQ("baidu.com:80", channel._service_name);
+    ASSERT_EQ(0, channel.Init("http://baidu.com:8888", "rr", &opt));
+    ASSERT_EQ("baidu.com:8888", channel._service_name);
+
+    ASSERT_EQ(0, channel.Init("https://baidu.com", &opt));
+    ASSERT_EQ("baidu.com", channel._service_name);
+    ASSERT_EQ(0, channel.Init("https://baidu.com:443", &opt));
+    ASSERT_EQ("baidu.com:443", channel._service_name);
+    ASSERT_EQ(0, channel.Init("https://baidu.com", 443, &opt));
+    ASSERT_EQ("baidu.com:443", channel._service_name);
+    ASSERT_EQ(0, channel.Init("https://baidu.com:1443", &opt));
+    ASSERT_EQ("baidu.com:1443", channel._service_name);
+    ASSERT_EQ(0, channel.Init("https://baidu.com", 1443, &opt));
+    ASSERT_EQ("baidu.com:1443", channel._service_name);
     ASSERT_EQ(0, channel.Init("https://baidu.com", "rr", &opt));
     ASSERT_EQ("baidu.com", channel._service_name);
+    ASSERT_EQ(0, channel.Init("https://baidu.com:443", "rr", &opt));
+    ASSERT_EQ("baidu.com:443", channel._service_name);
+    ASSERT_EQ(0, channel.Init("https://baidu.com:1443", "rr", &opt));
+    ASSERT_EQ("baidu.com:1443", channel._service_name);
 
     const char *address_list[] =  {
         "10.127.0.1:1234",


### PR DESCRIPTION
当前brpc的实现中，如果http请求，uri没有设置全地址，比如"/get_result?a=b"，那么会默认用ip+port作为HTTP 报头的header字段。
但是这样有问题，即使我的Channel初始化的时候使用的是域名，比如：`http://www.foo.com`，最后对对端看到的还是ip+端口。但像Apache/Nginx这种Web Server都是只是单地址多服务的，`http://www.foo.com` 和 `www.bar.com` 可能是同一个ip和端口（对应的是Apache的地址），然后Web Server会通过Host字段来路由到具体的服务。如果Apache看到的是Ip+端口，则不知道该把请求路由到哪个服务。

当前只能通过发送请求之时给uri填写完整的路径来解决，比如`http://www.foo.com/get_result?a=b`，但是感觉还是应该框架补全能力比较好。
因为比如我有多个环境，有测试、生产环境。他们访问下游HTTP服务的时候，每个环境的服务请求的接口地址是不同的。
比如生产环境是：`http://www.foo.com/get_result?a=b`，而测试环境是`http://www.foo-test.com/get_result?a=b`，我的服务在给Channel初始化的时候已经依据环境来用不同的域名地址进行了初始化。但是当实际给下游发请求的时候（CallMethod之前构造http_request的时候），还需要再判断一遍系统运行环境，再给cntl->http_request().uri() 视环境来赋不同的值。有些冗余，我感觉还是应该框架做好，减少冗余配置和冗余判断。

当然要实现这一feature，可实现的方案有很多。我这里采用的方案是也是当前感觉改动最小，影响最小但能达到目的的一个。受限于Brpc的历史设计，导致从URL解析出来的域名（或机器名，hostname）没有被存储。
因此我这里重新做了ParseUrl和hostname2ip的操作。虽然Init过程中其实之前就有间接调用到这两个函数，但是确实无法被Channel拿到结果。

