### PR TITLE
Support IPV6 and Unix domain socket

### DIFF
--- a/docs/cn/client.md
+++ b/docs/cn/client.md
@@ -48,10 +48,14 @@ int Init(const char* server_addr, int port, const ChannelOptions* options);
 - 127.0.0.1:80
 - www.foo.com:8765
 - localhost:9000
+- [::1]:8080      # IPV6
+- unix:path.sock  # Unix domain socket
 
 不合法的"server_addr_and_port"：
 - 127.0.0.1:90000     # 端口过大
 - 10.39.2.300:8000   # 非法的ip
+
+关于IPV6和Unix domain socket的使用，详见 [EndPoint](endpoint.md)。
 
 # 连接服务集群
 
@@ -797,7 +801,7 @@ http/h2 body的压缩方法见[client压缩request body](http_client.md#压缩re
 
 ### Q: brpc能用unix domain socket吗
 
-不能。同机TCP socket并不走网络，相比unix domain socket性能只会略微下降。一些不能用TCP socket的特殊场景可能会需要，以后可能会扩展支持。
+支持，参考 [EndPoint](endpoint.md).
 
 ### Q: Fail to connect to xx.xx.xx.xx:xxxx, Connection refused
 

--- a/docs/cn/endpoint.md
+++ b/docs/cn/endpoint.md
@@ -1,0 +1,61 @@
+# UDS及IPV6支持
+
+butil::EndPoint已经支持UDS(Unix Domain Socket)及IPV6。
+
+## 基本用法
+代码用法：
+
+```cpp
+EndPoint ep;
+str2endpoint("unix:path.sock", &ep); // 初始化一个UDS的EndPoint
+str2endpoint("[::1]:8086", &ep);  // 初始化一个IPV6的EndPoint
+str2endpoint("[::1]", 8086, &ep);  // 初始化一个IPV6的EndPoint
+ 
+// 获取EndPoint的类型
+sa_family_t type = get_endpoint_type(ep); // 可能为AF_INET、AF_INET6或AF_UNIX
+ 
+// 使用EndPoint，和原来的方式一样
+LOG(DEBUG) << ep; // 打印EndPoint
+std::string ep_str = endpoint2str(ep).c_str(); // EndPoint转str
+tcp_listen(ep); // 用监听EndPoint表示的tcp端口
+tcp_connect(ep, NULL); // 用连接EndPoint表示的tcp端口
+ 
+sockaddr_storage ss;
+socklen_t socklen = 0;
+endpoint2sockaddr(ep, &ss, &socklen); // 将EndPoint转为sockaddr结构，以便调用系统函数
+```
+
+## 在brpc中使用UDS或IPV6
+
+只需要在原来输入IPV4字符串的时候，填写UDS路径或IPV6地址即可，如：
+
+```cpp
+server.Start("unix:path.sock", options); // 启动server监听UDS地址
+server.Start("[::0]:8086", options);  // 启动server监听IPV6地址
+ 
+channel.Init("unix:path.sock", options); // 初始化single server的Channel，访问UDS地址
+channel.Init("list://[::1]:8086,[::1]:8087", "rr", options); // 初始化带LB的Channel，访问IPV6地址
+```
+
+通过 example/echo_c++ ，展示了如何使用UDS或IPV6：
+
+```bash
+./echo_server -listen_addr='unix:path.sock' & # 启动Server监听UDS地址
+./echo_server -listen_addr='[::0]:8080' & # 启动Server监听IPV6端口
+
+./echo_client -server='unix:path.sock' # 启动Client访问UDS地址
+./echo_client -server='[::1]:8080' # 启动Client访问IPV6端口
+```
+
+## 限制
+
+由于EndPoint结构被广泛地使用，为了保证对存量代码的兼容性（包括ABI兼容性），目前采用的实现方式是不修改EndPoint的ABI定义，使用原来的ip字段作为id，port字段来做为扩展标记，把真正的信息存在一个外部的数据结构中。
+
+这种实现方式对于现存的仅使用IPV4的代码是完全兼容的，但对于使用UDS或IPV6的用户，有些代码是不兼容的，比如直接访问EndPoint的ip和port成员的代码。
+
+关于UDS和IPV6，目前已知的一些限制：
+
+- 不兼容rpcz
+- 不支持使用PortRange方式启动server
+- 不支持在ServerOption中指定internal_port
+- IPV6不支持link local地址（fe80::开头的地址)

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -210,7 +210,13 @@ int Start(int port, const ServerOptions* opt);
 int Start(const char *ip_str, PortRange port_range, const ServerOptions *opt);  // r32009后增加
 ```
 
-"localhost:9000", "cq01-cos-dev00.cq01:8000", “127.0.0.1:7000"都是合法的`ip_and_port_str`。
+合法的`ip_and_port_str`：
+
+- 127.0.0.1:80    # IPV4
+- [::1]:8080      # IPV6
+- unix:path.sock  # Unix domain socket
+
+关于IPV6和Unix domain socket的使用，详见 [EndPoint](endpoint.md)。
 
 `options`为NULL时所有参数取默认值，如果你要使用非默认值，这么做就行了：
 

--- a/docs/cn/streaming_log.md
+++ b/docs/cn/streaming_log.md
@@ -135,6 +135,8 @@ TRACE: ... Items: item1 item2 item3
 
 noflush支持bthread，可以实现类似于UB的pushnotice的效果，即检索线程一路打印都暂不刷出（加上noflush），直到最后检索结束时再一次性刷出。注意，如果检索过程是异步的，就不应该使用noflush，因为异步显然会跨越bthread，使noflush仍然失效。
 
+> 注意：如果编译时开启了glog选项，则不支持noflush。
+
 ## LOG_IF
 
 `LOG_IF(log_level, condition)`只有当condition成立时才会打印，相当于if (condition) { LOG() << ...; }，但更加简短。比如：

--- a/src/brpc/builtin/index_service.cpp
+++ b/src/brpc/builtin/index_service.cpp
@@ -48,8 +48,6 @@ void IndexService::default_method(::google::protobuf::RpcController* controller,
     Controller *cntl = (Controller*)controller;
     cntl->http_response().set_content_type("text/plain");
     const Server* server = cntl->server();
-    const butil::EndPoint my_addr(butil::my_ip(),
-                                 server->listen_address().port);
     const bool use_html = UseHTML(cntl->http_request());
     const bool as_more = cntl->http_request().uri().GetQuery("as_more");
     if (use_html && !as_more) {
@@ -144,8 +142,14 @@ void IndexService::default_method(::google::protobuf::RpcController* controller,
            << " : Profiling growth of heap"
            << (!IsHeapProfilerEnabled() ? " (disabled)" : "") << NL;
     }
-    os << "curl -H 'Content-Type: application/json' -d 'JSON' " << my_addr
-       << "/ServiceName/MethodName : Call method by http+json" << NL
+    os << "curl -H 'Content-Type: application/json' -d 'JSON' ";
+    if (butil::is_endpoint_extended(server->listen_address())) {
+        os << "<listen_address>";
+    } else {
+        const butil::EndPoint my_addr(butil::my_ip(), server->listen_address().port);
+        os << my_addr;
+    }
+    os << "/ServiceName/MethodName : Call method by http+json" << NL
     
        << Path("/version", html_addr)
        << " : Version of this server, set by Server::set_version()" << NL

--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -301,7 +301,7 @@ int Channel::InitSingle(const butil::EndPoint& server_addr_and_port,
         }
     }
     const int port = server_addr_and_port.port;
-    if (port < 0 || port > 65535) {
+    if (port < 0) {
         LOG(ERROR) << "Invalid port=" << port;
         return -1;
     }

--- a/src/brpc/policy/consistent_hashing_load_balancer.cpp
+++ b/src/brpc/policy/consistent_hashing_load_balancer.cpp
@@ -69,7 +69,7 @@ bool DefaultReplicaPolicy::Build(ServerId server,
     }
     replicas->clear();
     for (size_t i = 0; i < num_replicas; ++i) {
-        char host[32];
+        char host[256];
         int len = snprintf(host, sizeof(host), "%s-%lu",
                            endpoint2str(ptr->remote_side()).c_str(), i);
         ConsistentHashingLoadBalancer::Node node;

--- a/src/brpc/policy/domain_naming_service.cpp
+++ b/src/brpc/policy/domain_naming_service.cpp
@@ -122,6 +122,7 @@ int DomainNamingService::GetServers(const char* dns_name,
     }
 #endif
 
+    //TODO add protocols other than IPv4 supports
     butil::EndPoint point;
     point.port = port;
     for (int i = 0; result->h_addr_list[i] != NULL; ++i) {

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -65,7 +65,8 @@ DEFINE_int32(http_body_compress_threshold, 512, "Not compress http body when "
 DEFINE_string(http_header_of_user_ip, "", "http requests sent by proxies may "
               "set the client ip in http headers. When this flag is non-empty, "
               "brpc will read ip:port from the specified header for "
-              "authorization and set Controller::remote_side()");
+              "authorization and set Controller::remote_side(). Currently, "
+              "support IPv4 address only.");
 
 DEFINE_bool(pb_enum_as_number, false,
             "[Not recommended] Convert enums in "
@@ -82,6 +83,7 @@ static bool GetUserAddressFromHeaderImpl(const HttpHeader& headers,
     if (user_addr_str == NULL) {
         return false;
     }
+    //TODO add protocols other than IPv4 supports.
     if (user_addr_str->find(':') == std::string::npos) {
         if (butil::str2ip(user_addr_str->c_str(), &user_addr->ip) != 0) {
             LOG(WARNING) << "Fail to parse ip from " << *user_addr_str;

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -1046,11 +1046,9 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
 
     // Print tips to server launcher.
     if (butil::is_endpoint_extended(_listen_addr)) {
-        LOG(INFO) << "Server[" << version() << "] is serving on " << _listen_addr << noflush;
-        if (_options.has_builtin_services) {
-            LOG(INFO) << " with builtin service" << noflush;
-        }
-        LOG(INFO) << '.';
+        const char* builtin_msg = _options.has_builtin_services ? " with builtin service" : "";
+        LOG(INFO) << "Server[" << version() << "] is serving on " << _listen_addr
+                  << builtin_msg << '.';
         //TODO add TrackMe support
     } else {
         int http_port = _listen_addr.port;

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -559,7 +559,7 @@ friend class Controller;
     // Create acceptor with handlers of protocols.
     Acceptor* BuildAcceptor();
 
-    int StartInternal(const butil::ip_t& ip,
+    int StartInternal(const butil::EndPoint& endpoint,
                       const PortRange& port_range,
                       const ServerOptions *opt);
 

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1115,7 +1115,13 @@ int Socket::Connect(const timespec* abstime,
     } else {
         _ssl_state = SSL_OFF;
     }
-    butil::fd_guard sockfd(socket(AF_INET, SOCK_STREAM, 0));
+    struct sockaddr_storage serv_addr;
+    socklen_t addr_size = 0;
+    if (butil::endpoint2sockaddr(remote_side(), &serv_addr, &addr_size) != 0) {
+        PLOG(ERROR) << "Fail to get sockaddr";
+        return -1;
+    }
+    butil::fd_guard sockfd(socket(serv_addr.ss_family, SOCK_STREAM, 0));
     if (sockfd < 0) {
         PLOG(ERROR) << "Fail to create socket";
         return -1;
@@ -1124,13 +1130,8 @@ int Socket::Connect(const timespec* abstime,
     // We need to do async connect (to manage the timeout by ourselves).
     CHECK_EQ(0, butil::make_non_blocking(sockfd));
     
-    struct sockaddr_in serv_addr;
-    bzero((char*)&serv_addr, sizeof(serv_addr));
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr = remote_side().ip;
-    serv_addr.sin_port = htons(remote_side().port);
     const int rc = ::connect(
-        sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+        sockfd, (struct sockaddr*)&serv_addr, addr_size);
     if (rc != 0 && errno != EINPROGRESS) {
         PLOG(WARNING) << "Fail to connect to " << remote_side();
         return -1;
@@ -1217,13 +1218,12 @@ int Socket::CheckConnected(int sockfd) {
         return -1;
     }
 
-    struct sockaddr_in client;
-    socklen_t size = sizeof(client);
-    CHECK_EQ(0, getsockname(sockfd, (struct sockaddr*) &client, &size));
+    butil::EndPoint local_point;
+    CHECK_EQ(0, butil::get_local_side(sockfd, &local_point));
     LOG_IF(INFO, FLAGS_log_connected)
             << "Connected to " << remote_side()
             << " via fd=" << (int)sockfd << " SocketId=" << id()
-            << " local_port=" << ntohs(client.sin_port);
+            << " local_side=" << local_point;
     if (CreatedByConnect()) {
         g_vars->channel_conn << 1;
     }

--- a/src/butil/details/extended_endpoint.hpp
+++ b/src/butil/details/extended_endpoint.hpp
@@ -1,0 +1,377 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef BUTIL_DETAILS_EXTENDED_ENDPOINT_H
+#define BUTIL_DETAILS_EXTENDED_ENDPOINT_H
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/un.h>
+#include <mutex>
+#include <unordered_set>
+#include "butil/endpoint.h"
+#include "butil/logging.h"
+#include "butil/strings/string_piece.h"
+#include "butil/resource_pool.h"
+#include "butil/memory/singleton_on_pthread_once.h"
+
+namespace butil {
+namespace details {
+
+#if __cplusplus >= 201103L
+static_assert(sizeof(EndPoint) == sizeof(EndPoint::ip) + sizeof(EndPoint::port),
+        "EndPoint size mismatch with the one in POD-style, may cause ABI problem");
+#endif
+
+// For ipv6/unix socket address.
+//
+// We have to keep butil::EndPoint ABI compatible because it is used so widely, and the size of butil::EndPoint is
+// too small to store more information such as ipv6 address.
+// We store enough information about endpoint in such tiny struct by putting real things in another big object
+// holding by ResourcePool. The EndPoint::ip saves ResourceId, while EndPoint::port denotes if the EndPoint object
+// is an old style ipv4 endpoint.
+// Note that since ResourcePool has been implemented in bthread, we copy it into this repo and change its namespace to
+// butil::details. Those two headers will not be published.
+
+// If EndPoint.port equals to this value, we should get the extended endpoint in resource pool.
+const static int EXTENDED_ENDPOINT_PORT = 123456789;
+
+class ExtendedEndPoint;
+
+// A global unordered set to dedup ExtendedEndPoint
+// ExtendedEndPoints which have same ipv6/unix socket address must have same id,
+// so that user can simply use the value of EndPoint for comparision.
+class GlobalEndPointSet {
+public:
+    ExtendedEndPoint* insert(ExtendedEndPoint* p);
+
+    void erase(ExtendedEndPoint* p);
+
+    static GlobalEndPointSet* instance() {
+        return ::butil::get_leaky_singleton<GlobalEndPointSet>();
+    }
+
+private:
+    struct Hash {
+        size_t operator()(ExtendedEndPoint* const& p) const;
+    };
+
+    struct Equals {
+        bool operator()(ExtendedEndPoint* const& p1, ExtendedEndPoint* const& p2) const;
+    };
+
+    typedef std::unordered_set<ExtendedEndPoint*, Hash, Equals> SetType;
+    SetType _set;
+    std::mutex _mutex;
+};
+
+class ExtendedEndPoint {
+public:
+    // Construct ExtendedEndPoint.
+    // User should use create() functions to get ExtendedEndPoint instance.
+    ExtendedEndPoint(void) {
+        _ref_count.store(0, butil::memory_order_relaxed);
+        _u.sa.sa_family = AF_UNSPEC;
+    }
+
+public:
+    // Create ExtendedEndPoint.
+    // If creation is successful, create()s will embed the ExtendedEndPoint instance in the given EndPoint*,
+    // and return it as well. Or else, the given EndPoint* won't be touched.
+    //
+    // The format of the parameter is inspired by nginx.
+    // Valid forms are:
+    // - ipv6
+    // without port: [2400:da00::3b0b]
+    // with    port: [2400:da00::3b0b]:8080
+    // - unix domain socket
+    // abslute path : unix:/path/to/file.sock
+    // relative path: unix:path/to/file.sock
+
+    static ExtendedEndPoint* create(StringPiece sp, EndPoint* ep) {
+        sp.trim_spaces();
+        if (sp.empty()) {
+            return NULL;
+        }
+        if (sp[0] == '[') {
+            size_t colon_pos = sp.find(']');
+            if (colon_pos == StringPiece::npos || colon_pos == 1 /* [] is invalid */ || ++colon_pos >= sp.size()) {
+                return NULL;
+            }
+            StringPiece port_sp = sp.substr(colon_pos);
+            if (port_sp.size() < 2 /* colon and at least one integer */ || port_sp[0] != ':') {
+                return NULL;
+            }
+            port_sp.remove_prefix(1); // remove `:'
+            if (port_sp.size() > 5) { // max 65535
+                return NULL;
+            }
+            char buf[6];
+            buf[port_sp.copy(buf, port_sp.size())] = '\0';
+            char* end = NULL;
+            int port = ::strtol(buf, &end, 10 /* base */);
+            if (end != buf + port_sp.size()) {
+                return NULL;
+            }
+            return create(sp.substr(0, colon_pos), port, ep);
+        } else if (sp.starts_with("unix:")) {
+            return create(sp, EXTENDED_ENDPOINT_PORT, ep);
+        }
+        return NULL;
+    }
+
+    static ExtendedEndPoint* create(StringPiece sp, int port, EndPoint* ep) {
+        sp.trim_spaces();
+        if (sp.empty()) {
+            return NULL;
+        }
+        ExtendedEndPoint* eep = NULL;
+        if (sp[0] == '[' && port >= 0 && port <= 65535) {
+            if (sp.back() != ']' || sp.size() == 2 || sp.size() - 2 >= INET6_ADDRSTRLEN) {
+                return NULL;
+            }
+            char buf[INET6_ADDRSTRLEN];
+            buf[sp.copy(buf, sp.size() - 2 /* skip `[' and `]' */, 1 /* skip `[' */)] = '\0';
+
+            in6_addr addr;
+            if (inet_pton(AF_INET6, buf, &addr) != 1 /* succ */) {
+                return NULL;
+            }
+
+            eep = new_extended_endpoint(AF_INET6);
+            if (eep) {
+                eep->_u.in6.sin6_addr = addr;
+                eep->_u.in6.sin6_port = htons(port);
+                eep->_u.in6.sin6_flowinfo = 0u;
+                eep->_u.in6.sin6_scope_id = 0u;
+                eep->_socklen = sizeof(_u.in6);
+            }
+        } else if (sp.starts_with("unix:")) { // ignore port
+            sp.remove_prefix(5); // remove `unix:'
+            if (sp.empty() || sp.size() >= UDS_PATH_SIZE) {
+                return NULL;
+            }
+            eep = new_extended_endpoint(AF_UNIX);
+            if (eep) {
+                int size = sp.copy(eep->_u.un.sun_path, sp.size());
+                eep->_u.un.sun_path[size] = '\0';
+                eep->_socklen = offsetof(sockaddr_un, sun_path) + size + 1;
+            }
+        }
+        if (eep) {
+            eep = dedup(eep);
+            eep->embed_to(ep);
+        }
+        return eep;
+    }
+
+    static ExtendedEndPoint* create(sockaddr_storage* ss, socklen_t size, EndPoint* ep) {
+        ExtendedEndPoint* eep = NULL;
+        if (ss->ss_family == AF_INET6 || ss->ss_family == AF_UNIX) {
+            eep = new_extended_endpoint(ss->ss_family);
+        }
+        if (eep) {
+            memcpy(&eep->_u.ss, ss, size);
+            eep->_socklen = size;
+            if (ss->ss_family == AF_UNIX && size == offsetof(sockaddr_un, sun_path)) {
+                // See unix(7): When the address of an unnamed socket is returned, 
+                // its length is sizeof(sa_family_t), and sun_path should not be inspected.
+                eep->_u.un.sun_path[0] = '\0';
+            }
+            eep = dedup(eep);
+            eep->embed_to(ep);
+        }
+        return eep;
+    }
+
+    // Get ExtendedEndPoint instance from EndPoint
+    static ExtendedEndPoint* address(const EndPoint& ep) {
+        if (!is_extended(ep)) {
+            return NULL;
+        }
+        ::butil::ResourceId<ExtendedEndPoint> id;
+        id.value = ep.ip.s_addr;
+        ExtendedEndPoint* eep = ::butil::address_resource<ExtendedEndPoint>(id);
+        CHECK(eep) << "fail to address ExtendedEndPoint from EndPoint";
+        return eep;
+    }
+
+    // Check if an EndPoint has embedded ExtendedEndPoint
+    static bool is_extended(const butil::EndPoint& ep) {
+        return ep.port == EXTENDED_ENDPOINT_PORT;
+    }
+
+private:
+    friend class GlobalEndPointSet;
+
+    static GlobalEndPointSet* global_set() {
+        return GlobalEndPointSet::instance();
+    }
+
+    static ExtendedEndPoint* new_extended_endpoint(sa_family_t family) {
+        ::butil::ResourceId<ExtendedEndPoint> id;
+        ExtendedEndPoint* eep = ::butil::get_resource(&id);
+        if (eep) {
+            int64_t old_ref = eep->_ref_count.load(butil::memory_order_relaxed);
+            CHECK(old_ref == 0) << "new ExtendedEndPoint has reference " << old_ref;
+            CHECK(eep->_u.sa.sa_family == AF_UNSPEC) << "new ExtendedEndPoint has family " << eep->_u.sa.sa_family << " set";
+            eep->_ref_count.store(1, butil::memory_order_relaxed);
+            eep->_id = id;
+            eep->_u.sa.sa_family = family;
+        }
+        return eep;
+    }
+
+    void embed_to(EndPoint* ep) const {
+        CHECK(0 == _id.value >> 32) << "ResourceId beyond index";
+        ep->reset();
+        ep->ip = ip_t{static_cast<uint32_t>(_id.value)};
+        ep->port = EXTENDED_ENDPOINT_PORT;
+    }
+
+    static ExtendedEndPoint* dedup(ExtendedEndPoint* eep) {
+        eep->_hash = std::hash<std::string>()(std::string((const char*)&eep->_u, eep->_socklen));
+
+        ExtendedEndPoint* first_eep = global_set()->insert(eep);
+        if (first_eep != eep) {
+            eep->_ref_count.store(0, butil::memory_order_relaxed);
+            eep->_u.sa.sa_family = AF_UNSPEC;
+            ::butil::return_resource(eep->_id);
+        }
+        return first_eep;
+    }
+
+public:
+
+    void dec_ref(void) {
+        int64_t old_ref = _ref_count.fetch_sub(1, butil::memory_order_relaxed);
+        CHECK(old_ref >= 1) << "ExtendedEndPoint has unexpected reference " << old_ref;
+        if (old_ref == 1) {
+            global_set()->erase(this);
+            _u.sa.sa_family = AF_UNSPEC;
+            ::butil::return_resource(_id);
+        }
+    }
+
+    void inc_ref(void) {
+        int64_t old_ref = _ref_count.fetch_add(1, butil::memory_order_relaxed);
+        CHECK(old_ref >= 1) << "ExtendedEndPoint has unexpected reference " << old_ref;
+    }
+
+    sa_family_t family(void) const {
+        return _u.sa.sa_family;
+    }
+
+    int to(sockaddr_storage* ss) const {
+        memcpy(ss, &_u.ss, _socklen);
+        return _socklen;
+    }
+
+    void to(EndPointStr* ep_str) const {
+        if (_u.sa.sa_family == AF_UNIX) {
+            snprintf(ep_str->_buf, sizeof(ep_str->_buf), "unix:%s", _u.un.sun_path);
+        } else if (_u.sa.sa_family == AF_INET6) {
+            char buf[INET6_ADDRSTRLEN] = {0};
+            const char* ret = inet_ntop(_u.sa.sa_family, &_u.in6.sin6_addr, buf, sizeof(buf));
+            CHECK(ret) << "fail to do inet_ntop";
+            snprintf(ep_str->_buf, sizeof(ep_str->_buf), "[%s]:%d", buf, ntohs(_u.in6.sin6_port));
+        } else {
+            CHECK(0) << "family " << _u.sa.sa_family << " not supported";
+        }
+    }
+
+    int to_hostname(char* host, size_t host_len) const {
+        if (_u.sa.sa_family == AF_UNIX) {
+            snprintf(host, host_len, "unix:%s", _u.un.sun_path);
+            return 0;
+        } else if (_u.sa.sa_family == AF_INET6) {
+            sockaddr_in6 sa = _u.in6;
+            if (getnameinfo((const sockaddr*) &sa, sizeof(sa), host, host_len, NULL, 0, NI_NAMEREQD) != 0) {
+                return -1;
+            }
+            size_t len = ::strlen(host);
+            if (len + 1 < host_len) {
+                snprintf(host + len, host_len - len, ":%d", _u.in6.sin6_port);
+            }
+            return 0;
+        } else {
+            CHECK(0) << "family " << _u.sa.sa_family << " not supported";
+            return -1;
+        }
+    }
+
+private:
+    static const size_t UDS_PATH_SIZE = sizeof(sockaddr_un::sun_path);
+
+    butil::atomic<int64_t> _ref_count;
+    butil::ResourceId<ExtendedEndPoint> _id;
+    size_t _hash;  // pre-compute hash code of sockaddr for saving unordered_set query time
+    socklen_t _socklen; // valid data length of sockaddr
+    union {
+        sockaddr sa;
+        sockaddr_in6 in6;
+        sockaddr_un un;
+        sockaddr_storage ss;
+    } _u;
+};
+
+inline ExtendedEndPoint* GlobalEndPointSet::insert(ExtendedEndPoint* p) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    auto it = _set.find(p);
+    if (it != _set.end()) {
+        if ((*it)->_ref_count.fetch_add(1, butil::memory_order_relaxed) == 0) {
+            // another thread is calling dec_ref(), do not reuse it
+            (*it)->_ref_count.fetch_sub(1, butil::memory_order_relaxed);
+            _set.erase(it);
+            _set.insert(p);
+            return p;
+        } else {
+            // the ExtendedEndPoint is valid, reuse it 
+            return *it;
+        }
+    }
+    _set.insert(p);
+    return p;
+}
+
+inline void GlobalEndPointSet::erase(ExtendedEndPoint* p) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    auto it = _set.find(p);
+    if (it == _set.end() || *it != p) {
+        // another thread has been erase it
+        return;
+    }
+    _set.erase(it);
+}
+
+inline size_t GlobalEndPointSet::Hash::operator()(ExtendedEndPoint* const& p) const {
+    return p->_hash;
+}
+
+inline bool GlobalEndPointSet::Equals::operator()(ExtendedEndPoint* const& p1, ExtendedEndPoint* const& p2) const {
+    return p1->_socklen == p2->_socklen 
+            && memcmp(&p1->_u, &p2->_u, p1->_socklen) == 0;
+}
+
+} // namespace details
+} // namespace butil
+
+#endif // BUTIL_DETAILS_EXTENDED_ENDPOINT_H

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -556,25 +556,28 @@ TEST_F(LoadBalancerTest, consistent_hashing) {
             "10.36.150.32:8833", 
             "10.92.149.48:8833", 
             "10.42.122.201:8833",
+            "[2408:871a:2100:3:0:ff:b025:348d]:8833",
+            "unix:test.sock",
     };
     for (size_t round = 0; round < ARRAY_SIZE(hashs); ++round) {
         brpc::policy::ConsistentHashingLoadBalancer chlb(hash_type[round]);
         std::vector<brpc::ServerId> ids;
         std::vector<butil::EndPoint> addrs;
-        for (int j = 0;j < 5; ++j) 
-        for (int i = 0; i < 5; ++i) {
-            const char *addr = servers[i];
-            //snprintf(addr, sizeof(addr), "192.168.1.%d:8080", i);
-            butil::EndPoint dummy;
-            ASSERT_EQ(0, str2endpoint(addr, &dummy));
-            brpc::ServerId id(8888);
-            brpc::SocketOptions options;
-            options.remote_side = dummy;
-            options.user = new SaveRecycle;
-            ASSERT_EQ(0, brpc::Socket::Create(options, &id.id));
-            ids.push_back(id);
-            addrs.push_back(dummy);
-            chlb.AddServer(id);
+        for (int j = 0;j < 5; ++j) {
+            for (size_t i = 0; i < ARRAY_SIZE(servers); ++i) {
+                const char *addr = servers[i];
+                //snprintf(addr, sizeof(addr), "192.168.1.%d:8080", i);
+                butil::EndPoint dummy;
+                ASSERT_EQ(0, str2endpoint(addr, &dummy));
+                brpc::ServerId id(8888);
+                brpc::SocketOptions options;
+                options.remote_side = dummy;
+                options.user = new SaveRecycle;
+                ASSERT_EQ(0, brpc::Socket::Create(options, &id.id));
+                ids.push_back(id);
+                addrs.push_back(dummy);
+                chlb.AddServer(id);
+            }
         }
         std::cout << chlb;
         for (int i = 0; i < 5; ++i) {

--- a/test/endpoint_unittest.cpp
+++ b/test/endpoint_unittest.cpp
@@ -20,8 +20,11 @@
 #include "butil/endpoint.h"
 #include "butil/logging.h"
 #include "butil/containers/flat_map.h"
+#include "butil/details/extended_endpoint.hpp"
 
 namespace {
+
+using butil::details::ExtendedEndPoint;
 
 TEST(EndPointTest, comparisons) {
     butil::EndPoint p1(butil::int2ip(1234), 5678);
@@ -146,6 +149,328 @@ TEST(EndPointTest, flat_map) {
     LOG(INFO) << "bucket info max long=" << info.longest_length
         << " avg=" << info.average_length << std::endl;
     ASSERT_LT(info.longest_length, 32ul) << "detect hash collision and it's too large.";
+}
+
+void* server_proc(void* arg) {
+    int listen_fd = (int64_t)arg;
+    sockaddr_storage ss;
+    socklen_t len = sizeof(ss);
+    int fd = accept(listen_fd, (sockaddr*)&ss, &len);
+    if (fd > 0) {
+        close(fd);
+    }
+    return (void*)(int64_t)fd;
+}
+
+static void test_listen_connect(const std::string& server_addr, const std::string& exp_client_addr) {
+    butil::EndPoint point;
+    ASSERT_EQ(0, butil::str2endpoint(server_addr.c_str(), &point));
+    ASSERT_EQ(server_addr, butil::endpoint2str(point).c_str());
+
+    int listen_fd = butil::tcp_listen(point);
+    ASSERT_GT(listen_fd, 0);
+    pthread_t pid;
+    pthread_create(&pid, NULL, server_proc, (void*)(int64_t)listen_fd);
+
+    int fd = butil::tcp_connect(point, NULL);
+    ASSERT_GT(fd, 0);
+
+    butil::EndPoint point2;
+    ASSERT_EQ(0, butil::get_local_side(fd, &point2));
+
+    std::string s = butil::endpoint2str(point2).c_str();
+    if (butil::get_endpoint_type(point2) == AF_UNIX) {
+        ASSERT_EQ(exp_client_addr, s);
+    } else {
+        ASSERT_EQ(exp_client_addr, s.substr(0, exp_client_addr.size()));
+    }
+    ASSERT_EQ(0, butil::get_remote_side(fd, &point2));
+    ASSERT_EQ(server_addr, butil::endpoint2str(point2).c_str());
+    close(fd);
+
+    void* ret = nullptr;
+    pthread_join(pid, &ret);
+    ASSERT_GT((int64_t)ret, 0);
+    close(listen_fd);
+}
+
+static void test_parse_and_serialize(const std::string& instr, const std::string& outstr) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::str2endpoint(instr.c_str(), &ep));
+    butil::EndPointStr s = butil::endpoint2str(ep);
+    ASSERT_EQ(outstr, std::string(s.c_str()));
+}
+
+TEST(EndPointTest, ipv4) {
+    test_listen_connect("127.0.0.1:8787", "127.0.0.1:");
+}
+
+TEST(EndPointTest, ipv6) {
+    // FIXME: test environ may not support ipv6
+    // test_listen_connect("[::1]:8787", "[::1]:");
+
+    test_parse_and_serialize("[::1]:8080", "[::1]:8080");
+    test_parse_and_serialize("  [::1]:65535  ", "[::1]:65535");
+    test_parse_and_serialize("  [2001:0db8:a001:0002:0003:0ab9:C0A8:0102]:65535  ",
+                             "[2001:db8:a001:2:3:ab9:c0a8:102]:65535");
+
+    butil::EndPoint ep;
+    ASSERT_EQ(-1, butil::str2endpoint("[2001:db8:1:2:3:ab9:c0a8:102]", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("[2001:db8:1:2:3:ab9:c0a8:102]#654321", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("ipv6:2001:db8:1:2:3:ab9:c0a8:102", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("[", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("[::1", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("[]:80", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("[]", &ep));
+    ASSERT_EQ(-1, butil::str2endpoint("[]:", &ep));
+}
+
+TEST(EndPointTest, unix_socket) {
+    ::unlink("test.sock");
+    test_listen_connect("unix:test.sock", "unix:");
+    ::unlink("test.sock");
+
+    butil::EndPoint point;
+    ASSERT_EQ(-1, butil::str2endpoint("", &point));
+    ASSERT_EQ(-1, butil::str2endpoint("a.sock", &point));
+    ASSERT_EQ(-1, butil::str2endpoint("unix:", &point));
+    ASSERT_EQ(-1, butil::str2endpoint(" unix: ", &point));
+    ASSERT_EQ(0, butil::str2endpoint("unix://a.sock", 123, &point));
+    ASSERT_EQ(std::string("unix://a.sock"), butil::endpoint2str(point).c_str());
+
+    ASSERT_EQ(-1, butil::str2endpoint("unix:tooloooooooooooooooooooooooooooooooooooooooooooooooooo"
+        "ooooooooooooooooooooooooooooooooooooooooooooooong.sock", &point));
+    ASSERT_EQ(0, butil::str2endpoint(" unix:loooooooooooooooooooooooooooooooooooooooooooooooooooo"
+        "ooooooooooooooooooooooooooooooooooooooooooooooong.sock", &point));
+    ASSERT_EQ(std::string("unix:loooooooooooooooooooooooooooooooooooooooooooooooooooo"
+        "ooooooooooooooooooooooooooooooooooooooooooooooong.sock"), butil::endpoint2str(point).c_str());
+    char buf[128] = {0}; // braft use this size of buffer
+    size_t ret = snprintf(buf, sizeof(buf), "%s:%d", butil::endpoint2str(point).c_str(), INT_MAX);
+    ASSERT_LT(ret, sizeof(buf) - 1);
+}
+
+TEST(EndPointTest, original_endpoint) {
+    butil::EndPoint ep;
+    ASSERT_FALSE(ExtendedEndPoint::is_extended(ep));
+    ASSERT_EQ(NULL, ExtendedEndPoint::address(ep));
+
+    ASSERT_EQ(0, butil::str2endpoint("1.2.3.4:5678", &ep));
+    ASSERT_FALSE(ExtendedEndPoint::is_extended(ep));
+    ASSERT_EQ(NULL, ExtendedEndPoint::address(ep));
+
+    // ctor & dtor
+    {
+        butil::EndPoint ep2(ep);
+        ASSERT_FALSE(ExtendedEndPoint::is_extended(ep));
+        ASSERT_EQ(ep.ip, ep2.ip);
+        ASSERT_EQ(ep.port, ep2.port);
+    }
+
+    // assign
+    butil::EndPoint ep2;
+    ep2 = ep;
+    ASSERT_EQ(ep.ip, ep2.ip);
+    ASSERT_EQ(ep.port, ep2.port);
+}
+
+TEST(EndPointTest, extended_endpoint) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::str2endpoint("unix:sock.file", &ep));
+    ASSERT_TRUE(ExtendedEndPoint::is_extended(ep));
+    ExtendedEndPoint* eep = ExtendedEndPoint::address(ep);
+    ASSERT_TRUE(eep);
+    ASSERT_EQ(AF_UNIX, eep->family());
+    ASSERT_EQ(1, eep->_ref_count.load());
+
+    // copy ctor & dtor
+    {
+        butil::EndPoint tmp(ep);
+        ASSERT_EQ(2, eep->_ref_count.load());
+        ASSERT_EQ(eep, ExtendedEndPoint::address(tmp));
+        ASSERT_EQ(eep, ExtendedEndPoint::address(ep));
+    }
+    ASSERT_EQ(1, eep->_ref_count.load());
+
+    butil::EndPoint ep2;
+
+    // extended endpoint assigns to original endpoint
+    ep2 = ep;
+    ASSERT_EQ(2, eep->_ref_count.load());
+    ASSERT_EQ(eep, ExtendedEndPoint::address(ep2));
+
+    // original endpoint assigns to extended endpoint
+    ep2 = butil::EndPoint();
+    ASSERT_EQ(1, eep->_ref_count.load());
+    ASSERT_FALSE(ExtendedEndPoint::is_extended(ep2));
+
+    // extended endpoint assigns to extended endpoint
+    ASSERT_EQ(0, butil::str2endpoint("[::1]:2233", &ep2));
+    ExtendedEndPoint* eep2 = ExtendedEndPoint::address(ep2);
+    ASSERT_TRUE(eep2);
+    ep2 = ep;
+    // eep2 has been returned to resource pool, but we can still access it here unsafely.
+    ASSERT_EQ(0, eep2->_ref_count.load());
+    ASSERT_EQ(AF_UNSPEC, eep2->family());
+    ASSERT_EQ(2, eep->_ref_count.load());
+    ASSERT_EQ(eep, ExtendedEndPoint::address(ep));
+    ASSERT_EQ(eep, ExtendedEndPoint::address(ep2));
+
+    ASSERT_EQ(0, str2endpoint("[::1]:2233", &ep2));
+    ASSERT_EQ(1, eep->_ref_count.load());
+    eep2 = ExtendedEndPoint::address(ep2);
+    ASSERT_NE(eep, eep2);
+    ASSERT_EQ(1, eep2->_ref_count.load());
+}
+
+TEST(EndPointTest, endpoint_compare) {
+    butil::EndPoint ep1, ep2, ep3;
+
+    ASSERT_EQ(0, butil::str2endpoint("127.0.0.1:8080", &ep1));
+    ASSERT_EQ(0, butil::str2endpoint("127.0.0.1:8080", &ep2));
+    ASSERT_EQ(0, butil::str2endpoint("127.0.0.3:8080", &ep3));
+    ASSERT_EQ(ep1, ep2);
+    ASSERT_NE(ep1, ep3);
+
+    ASSERT_EQ(0, butil::str2endpoint("unix:sock1.file", &ep1));
+    ASSERT_EQ(0, butil::str2endpoint("unix:sock1.file", &ep2));
+    ASSERT_EQ(0, butil::str2endpoint("unix:sock3.file", &ep3));
+    ASSERT_EQ(ep1, ep2);
+    ASSERT_NE(ep1, ep3);
+
+    ASSERT_EQ(0, butil::str2endpoint("[::1]:2233", &ep1));
+    ASSERT_EQ(0, butil::str2endpoint("[::1]:2233", &ep2));
+    ASSERT_EQ(0, butil::str2endpoint("[::3]:2233", &ep3)); 
+    ASSERT_EQ(ep1, ep2);
+    ASSERT_NE(ep1, ep3);
+}
+
+TEST(EndPointTest, endpoint_sockaddr_conv_ipv4) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::str2endpoint("1.2.3.4:8086", &ep));
+
+    in_addr expected_in_addr;
+    bzero(&expected_in_addr, sizeof(expected_in_addr));
+    expected_in_addr.s_addr = 0x04030201u;
+
+    sockaddr_storage ss;
+    sockaddr_in* in4 = (sockaddr_in*) &ss;
+
+    memset(&ss, 'a', sizeof(ss));
+    ASSERT_EQ(0, butil::endpoint2sockaddr(ep, &ss));
+    ASSERT_EQ(AF_INET, ss.ss_family);
+    ASSERT_EQ(AF_INET, in4->sin_family);
+    in_port_t port = htons(8086);
+    ASSERT_EQ(port, in4->sin_port);
+    ASSERT_EQ(0, memcmp(&in4->sin_addr, &expected_in_addr, sizeof(expected_in_addr)));
+
+    sockaddr_storage ss2;
+    socklen_t ss2_size = 0;
+    memset(&ss2, 'b', sizeof(ss2));
+    ASSERT_EQ(0, butil::endpoint2sockaddr(ep, &ss2, &ss2_size));
+    ASSERT_EQ(ss2_size, sizeof(*in4));
+    ASSERT_EQ(0, memcmp(&ss2, &ss, sizeof(ss)));
+
+    butil::EndPoint ep2;
+    ASSERT_EQ(0, butil::sockaddr2endpoint(&ss, sizeof(*in4), &ep2));
+    ASSERT_EQ(ep2, ep);
+
+    ASSERT_EQ(AF_INET, butil::get_endpoint_type(ep));
+}
+
+TEST(EndPointTest, endpoint_sockaddr_conv_ipv6) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::str2endpoint("[::1]:8086", &ep));
+
+    in6_addr expect_in6_addr;
+    bzero(&expect_in6_addr, sizeof(expect_in6_addr));
+    expect_in6_addr.__in6_u.__u6_addr8[15] = 1;
+
+    sockaddr_storage ss;
+    const sockaddr_in6* sa6 = (sockaddr_in6*) &ss;
+
+    memset(&ss, 'a', sizeof(ss));
+    ASSERT_EQ(0, butil::endpoint2sockaddr(ep, &ss));
+    ASSERT_EQ(AF_INET6, ss.ss_family);
+    ASSERT_EQ(AF_INET6, sa6->sin6_family);
+    in_port_t port = htons(8086);
+    ASSERT_EQ(port, sa6->sin6_port);
+    ASSERT_EQ(0u, sa6->sin6_flowinfo);
+    ASSERT_EQ(0, memcmp(&expect_in6_addr, &sa6->sin6_addr, sizeof(in6_addr)));
+    ASSERT_EQ(0u, sa6->sin6_scope_id);
+
+    sockaddr_storage ss2;
+    socklen_t ss2_size = 0;
+    memset(&ss2, 'b', sizeof(ss2));
+    ASSERT_EQ(0, butil::endpoint2sockaddr(ep, &ss2, &ss2_size));
+    ASSERT_EQ(ss2_size, sizeof(*sa6));
+    ASSERT_EQ(0, memcmp(&ss2, &ss, sizeof(ss)));
+
+    butil::EndPoint ep2;
+    ASSERT_EQ(0, butil::sockaddr2endpoint(&ss, sizeof(*sa6), &ep2));
+    ASSERT_STREQ("[::1]:8086", butil::endpoint2str(ep2).c_str());
+
+    ASSERT_EQ(AF_INET6, butil::get_endpoint_type(ep));
+}
+
+TEST(EndPointTest, endpoint_sockaddr_conv_unix) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::str2endpoint("unix:sock.file", &ep));
+
+    sockaddr_storage ss;
+    const sockaddr_un* un = (sockaddr_un*) &ss;
+
+    memset(&ss, 'a', sizeof(ss));
+    ASSERT_EQ(0, butil::endpoint2sockaddr(ep, &ss));
+    ASSERT_EQ(AF_UNIX, ss.ss_family);
+    ASSERT_EQ(AF_UNIX, un->sun_family);
+    ASSERT_EQ(0, memcmp("sock.file", un->sun_path, 10));
+
+    sockaddr_storage ss2;
+    socklen_t ss2_size = 0;
+    memset(&ss2, 'b', sizeof(ss2));
+    ASSERT_EQ(0, butil::endpoint2sockaddr(ep, &ss2, &ss2_size));
+    ASSERT_EQ(offsetof(struct sockaddr_un, sun_path) + strlen("sock.file") + 1, ss2_size);
+    ASSERT_EQ(0, memcmp(&ss2, &ss, sizeof(ss)));
+
+    butil::EndPoint ep2;
+    ASSERT_EQ(0, butil::sockaddr2endpoint(&ss, sizeof(sa_family_t) + strlen(un->sun_path) + 1, &ep2));
+    ASSERT_STREQ("unix:sock.file", butil::endpoint2str(ep2).c_str());
+
+    ASSERT_EQ(AF_UNIX, butil::get_endpoint_type(ep));
+}
+
+void concurrent_proc(void* p) {
+    for (int i = 0; i < 10000; ++i) {
+        butil::EndPoint ep;
+        std::string str("127.0.0.1:8080");
+        ASSERT_EQ(0, butil::str2endpoint(str.c_str(), &ep));
+        ASSERT_EQ(str, butil::endpoint2str(ep).c_str());
+
+        str.assign("[::1]:8080");
+        ASSERT_EQ(0, butil::str2endpoint(str.c_str(), &ep));
+        ASSERT_EQ(str, butil::endpoint2str(ep).c_str());
+
+        str.assign("unix:test.sock");
+        ASSERT_EQ(0, butil::str2endpoint(str.c_str(), &ep));
+        ASSERT_EQ(str, butil::endpoint2str(ep).c_str());
+    }
+    *(int*)p = 1;
+}
+
+TEST(EndPointTest, endpoint_concurrency) {
+    const int T = 5;
+    pthread_t tids[T];
+    int rets[T] = {0};
+    for (int i = 0; i < T; ++i) {
+        pthread_create(&tids[i], nullptr, [](void* p) {
+            concurrent_proc(p);
+            return (void*)nullptr;
+        }, &rets[i]);
+    }
+    for (int i = 0; i < T; ++i) {
+        pthread_join(tids[i], nullptr);
+        ASSERT_EQ(1, rets[i]);
+    }
 }
 
 } // end of namespace


### PR DESCRIPTION
Solve #381, #879, #1403, #1462, #1552, #1561
Partially solve: #207

这里补充说明一下EndPoint扩展支持IPV6和UDS的思路：

整体上是遵循了@jamesge在 #207 中提到的思路，即EndPoint保持ABI兼容，不修改EndPoint的size，引入标志位（在port字段），然后ip字段是一个指向ExtendedEndPoint结构的ResourceId (使用butil::ResourcePool）。这样的好处就是对于现存的IPV4业务，是完全ABI兼容。

在ExtendedEndPoint结构中，引入了引用计数，这样拷贝EndPoint时会增加引用，释放EndPoint时会减少引用。

str2endpoint/endpoint2str都支持了IPV6和UDS。但是str2ip无法支持，因为ip_t结构没法在保持ABI兼容的情况下再扩展了。

tcp_connect/tcp_listen等方法也对扩展类型的EndPoint进行了支持，从而最小化对上层的改动。

另外由于EndPoint结构很多时候被直接当作值来使用（比如基于EndPoint的值进行排序、作为map/hash map的key等），为了兼容这些用法 ，我们需要保证同一个IPV4/IPV6/UDS的值，生成的EndPoint的值相同，因此做一个全局的去重，即值相同的EndPoint都指向同一个ExtendedEndPoint结构。这样对于内存也有一些节省（由于前面用了32位的ip字段来存储ResourceId，最多只能同时保存2^32个不同的EndPoint）。