### PR TITLE
fix gtest compile command

### DIFF
--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -37,7 +37,7 @@ sudo apt-get install -y libgoogle-perftools-dev
 
 如果你要运行测试，那么要安装并编译ligtest-dev（它没有被默认编译）：
 ```shell
-sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
+sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo env "PATH=$PATH" cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
 ```
 gtest源码目录可能变动，如果`/usr/src/gtest`不存在，请尝试`/usr/src/googletest/googletest`。
 

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -37,7 +37,7 @@ sudo apt-get install -y libgoogle-perftools-dev
 
 If you need to run tests, install and compile libgtest-dev (which is not compiled yet):
 ```shell
-sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
+sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo env "PATH=$PATH" cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
 ```
 The directory of gtest source code may be changed, try `/usr/src/googletest/googletest` if `/usr/src/gtest` is not there.
 


### PR DESCRIPTION
cmake编译的时候，如果没有新建一个build目录进入编译，直接`cmake .`的话要在前面加上`env PATH=$PATH`。
参考 .travis.yml 文件中编译gtest的写法。