### PR TITLE
Fix a typo of compress type

### DIFF
--- a/src/brpc/protocol.cpp
+++ b/src/brpc/protocol.cpp
@@ -139,7 +139,7 @@ void SerializeRequestDefault(butil::IOBuf* buf,
     }
     if (!SerializeAsCompressedData(*request, buf, cntl->request_compress_type())) {
         return cntl->SetFailed(
-            EREQUEST, "Fail to compress request, compress_tpye=%d",
+            EREQUEST, "Fail to compress request, compress_type=%d",
             (int)cntl->request_compress_type());
     }
 }


### PR DESCRIPTION
Fix a typo  in src/brpc/protocol.cpp, compress_tpye->compress_type