### PR TITLE
fix: word errors

### DIFF
--- a/src/brpc/event_dispatcher.cpp
+++ b/src/brpc/event_dispatcher.cpp
@@ -101,7 +101,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
     }
 
     // Set _consumer_thread_attr before creating epoll/kqueue thread to make sure
-    // everyting seems sane to the thread.
+    // everyting seems same to the thread.
     _consumer_thread_attr = (consumer_thread_attr  ?
                              *consumer_thread_attr : BTHREAD_ATTR_NORMAL);
 

--- a/src/brpc/load_balancer.h
+++ b/src/brpc/load_balancer.h
@@ -77,7 +77,7 @@ public:
     virtual bool AddServer(const ServerId& server) = 0;
 
     // Remove `server' from this balancer.
-    // Returns true iff the server was removed.
+    // Returns true if the server was removed.
     virtual bool RemoveServer(const ServerId& server) = 0;
 
     // Add a list of `servers' into this balancer.


### PR DESCRIPTION
修改两处代码注释的单词拼写错误