### PR TITLE
Fix rpc view `defer_close_second flag` typo

### DIFF
--- a/tools/rpc_view/rpc_view.cpp
+++ b/tools/rpc_view/rpc_view.cpp
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     // This keeps ad-hoc creation of channels reuse previous connections.
-    GFLAGS_NS::SetCommandLineOption("defer_close_seconds", "10");
+    GFLAGS_NS::SetCommandLineOption("defer_close_second", "10");
 
     brpc::Server server;
     server.set_version("rpc_view_server");


### PR DESCRIPTION
`defer_close_seconds` should be `defer_close_second`.