### PR TITLE
Fix a null deref in Controller::EndRPC

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -835,7 +835,7 @@ void Controller::EndRPC(const CompletionInfo& info) {
                          << info.id << " current_cid=" << current_id()
                          << " initial_cid=" << _correlation_id
                          << " stream_user_data=" << _current_call.stream_user_data
-                         << " sending_sock=" << *_current_call.sending_sock;
+                         << " sending_sock=" << _current_call.sending_sock.get();
         }
         _current_call.OnComplete(this, ECANCELED, false, false);
         if (_unfinished_call != NULL) {


### PR DESCRIPTION
调试brpc过程中在此处发生coredump，原因是_current_call.sending_sock为NULL。参照d465115cb对rdma分支中此处提出修改。