### PR TITLE
Improvement: brpc support higher version of protobuf

### DIFF
--- a/src/brpc/esp_message.cpp
+++ b/src/brpc/esp_message.cpp
@@ -52,6 +52,12 @@ EspMessage* EspMessage::New() const {
     return new EspMessage;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+EspMessage* EspMessage::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<EspMessage>(arena);
+}
+#endif
+
 void EspMessage::Clear() {
     head.body_len = 0;
     body.clear();

--- a/src/brpc/esp_message.h
+++ b/src/brpc/esp_message.h
@@ -54,6 +54,9 @@ public:
     // implements Message ----------------------------------------------
 
     EspMessage* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    EspMessage* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const EspMessage& from);

--- a/src/brpc/memcache.cpp
+++ b/src/brpc/memcache.cpp
@@ -63,6 +63,12 @@ MemcacheRequest* MemcacheRequest::New() const {
     return new MemcacheRequest;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+MemcacheRequest* MemcacheRequest::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<MemcacheRequest>(arena);
+}
+#endif
+
 void MemcacheRequest::Clear() {
     _buf.clear();
     _pipelined_count = 0;
@@ -206,6 +212,13 @@ const ::google::protobuf::Descriptor* MemcacheResponse::descriptor() {
 MemcacheResponse* MemcacheResponse::New() const {
     return new MemcacheResponse;
 }
+
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+MemcacheResponse*
+MemcacheResponse::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<MemcacheResponse>(arena);
+}
+#endif
 
 void MemcacheResponse::Clear() {
 }

--- a/src/brpc/memcache.h
+++ b/src/brpc/memcache.h
@@ -90,6 +90,9 @@ public:
 
     // Protobuf methods.
     MemcacheRequest* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    MemcacheRequest* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const MemcacheRequest& from);
@@ -200,6 +203,9 @@ public:
     // implements Message ----------------------------------------------
   
     MemcacheResponse* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    MemcacheResponse* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const MemcacheResponse& from);

--- a/src/brpc/nshead_message.cpp
+++ b/src/brpc/nshead_message.cpp
@@ -54,6 +54,12 @@ NsheadMessage* NsheadMessage::New() const {
     return new NsheadMessage;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+NsheadMessage* NsheadMessage::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<NsheadMessage>(arena);
+}
+#endif
+
 void NsheadMessage::Clear() {
     memset(&head, 0, sizeof(head));
     body.clear();

--- a/src/brpc/nshead_message.h
+++ b/src/brpc/nshead_message.h
@@ -50,6 +50,9 @@ public:
     // implements Message ----------------------------------------------
   
     NsheadMessage* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    NsheadMessage* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const NsheadMessage& from);

--- a/src/brpc/protocol.cpp
+++ b/src/brpc/protocol.cpp
@@ -203,7 +203,11 @@ BUTIL_FORCE_INLINE bool ParsePbFromZeroCopyStreamInlined(
     // According to source code of pb, SetTotalBytesLimit is not a simple set,
     // avoid calling the function when the limit is definitely unreached.
     if (PB_TOTAL_BYETS_LIMITS < FLAGS_max_body_size) {
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+        decoder.SetTotalBytesLimit(INT_MAX);
+#else
         decoder.SetTotalBytesLimit(INT_MAX, -1);
+#endif
     }
     return msg->ParseFromCodedStream(&decoder) && decoder.ConsumedEntireMessage();
 }

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -59,6 +59,12 @@ RedisRequest* RedisRequest::New() const {
     return new RedisRequest;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+RedisRequest* RedisRequest::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<RedisRequest>(arena);
+}
+#endif
+
 void RedisRequest::Clear() {
     _ncommand = 0;
     _has_error = false;
@@ -270,6 +276,12 @@ void RedisResponse::SetCachedSize(int size) const {
 RedisResponse* RedisResponse::New() const {
     return new RedisResponse;
 }
+
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+RedisResponse* RedisResponse::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<RedisResponse>(arena);
+}
+#endif
 
 void RedisResponse::Clear() {
     _first_reply.Reset();

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -108,6 +108,9 @@ public:
 
     // Protobuf methods.
     RedisRequest* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    RedisRequest* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const RedisRequest& from);
@@ -178,6 +181,9 @@ public:
     // implements Message ----------------------------------------------
   
     RedisResponse* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    RedisResponse* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const RedisResponse& from);

--- a/src/brpc/serialized_request.cpp
+++ b/src/brpc/serialized_request.cpp
@@ -53,6 +53,13 @@ SerializedRequest* SerializedRequest::New() const {
     return new SerializedRequest;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+SerializedRequest*
+SerializedRequest::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<SerializedRequest>(arena);
+}
+#endif
+
 void SerializedRequest::Clear() {
     _serialized.clear();
 }

--- a/src/brpc/serialized_request.h
+++ b/src/brpc/serialized_request.h
@@ -44,6 +44,9 @@ public:
     // implements Message ----------------------------------------------
   
     SerializedRequest* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    SerializedRequest* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const SerializedRequest& from);
     void Clear();

--- a/src/brpc/thrift_message.cpp
+++ b/src/brpc/thrift_message.cpp
@@ -59,6 +59,13 @@ ThriftFramedMessage* ThriftFramedMessage::New() const {
     return new ThriftFramedMessage;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+ThriftFramedMessage*
+ThriftFramedMessage::New(::google::protobuf::Arena* arena) const {
+    return CreateMaybeMessage<ThriftFramedMessage>(arena);
+}
+#endif
+
 void ThriftFramedMessage::Clear() {
     body.clear();
     if (_own_raw_instance) {

--- a/src/brpc/thrift_message.h
+++ b/src/brpc/thrift_message.h
@@ -84,6 +84,9 @@ public:
     // implements Message ----------------------------------------------
   
     ThriftFramedMessage* New() const;
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
+    ThriftFramedMessage* New(::google::protobuf::Arena* arena) const override;
+#endif
     void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from);
     void CopyFrom(const ThriftFramedMessage& from);


### PR DESCRIPTION
Support Protobuf 3.19.1 (breaking changes here: https://github.com/protocolbuffers/protobuf/commit/624d29d83306f3ce2c7e092dd44a891e04215e67) 

![image](https://user-images.githubusercontent.com/712433/147656148-bab973d3-9389-4e67-96fa-bad7a6862872.png)