### PR TITLE
fix(input_messenger) client side retry policy

### DIFF
--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -73,6 +73,7 @@ ParseResult InputMessenger::CutInputMessage(
                 _handlers[cur_index].parse(&m->_read_buf, m, read_eof, _handlers[cur_index].arg);
             if (result.is_ok() ||
                 result.error() == PARSE_ERROR_NOT_ENOUGH_DATA) {
+                m->set_preferred_index(cur_index);
                 *index = cur_index;
                 return result;
             } else if (result.error() != PARSE_ERROR_TRY_OTHERS) {
@@ -102,7 +103,7 @@ ParseResult InputMessenger::CutInputMessage(
                 // Try other protocols.
                 break;
             }
-        } while (1);
+        } while (true);
         // Clear context before trying next protocol which probably has
         // an incompatible context with the current one.
         if (m->parsing_context()) {


### PR DESCRIPTION
*Client Ptotocol Rule*: Ptotocol in client-side is fixed except `baidu_std`, because of `streaming_rpc` need create by `baidu_std` ptotocol. 

But in current implementation， there is a chance that client will accept message but not match with current protocol.

Case:

Client issue two RPC names `A` (use `hulu` protocol) and `B`(use` baidu_std` protocol) to server in the same connection, If A is sent before B,  client will set preferred protocol to `baidu_std`,  server will accept these two request and response. Then if response of B received by client  before A, B will be parsed success, because it is matched with current protocol(`baidu_std`). When parse response of A by current preferred ptotocol(`baidu_std`) will fail, according to *Client Ptotocol Rule*, client think this response is `streaming_rpc`, and try other ptotocols, then response of B will be parsed ok by `hulu` ptotocol.

That's the point: Shall  we just retry `streaming_rpc` when parse failed if current protocol is `baidu_std`? instead of trying all other protocols, or other ptotocol mixed with `baidu_std` will be accepted successfully.