### PR TITLE
Fix build warning, ByteSize() is deprecated, use ByteSizeLong() instead

### DIFF
--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -69,7 +69,7 @@ inline void PackRpcHeader(char* rpc_header, int meta_size, int payload_size) {
 
 static void SerializeRpcHeaderAndMeta(
     butil::IOBuf* out, const RpcMeta& meta, int payload_size) {
-    const int meta_size = meta.ByteSize();
+    const int meta_size = meta.ByteSizeLong();
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackRpcHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -152,7 +152,7 @@ inline void PackHuluHeader(char* hulu_header, int meta_size, int body_size) {
 template <typename Meta>
 static void SerializeHuluHeaderAndMeta(
     butil::IOBuf* out, const Meta& meta, int payload_size) {
-    const int meta_size = meta.ByteSize();
+    const int meta_size = meta.ByteSizeLong();
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackHuluHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/public_pbrpc_protocol.cpp
+++ b/src/brpc/policy/public_pbrpc_protocol.cpp
@@ -266,7 +266,7 @@ void PackPublicPbrpcRequest(butil::IOBuf* buf,
     nshead.magic_num = NSHEAD_MAGICNUM;
     snprintf(nshead.provider, sizeof(nshead.provider), "%s", PROVIDER);
     nshead.version = NSHEAD_VERSION;
-    nshead.body_len = pbreq.ByteSize();
+    nshead.body_len = pbreq.ByteSizeLong();
     buf->append(&nshead, sizeof(nshead));
 
     Span* span = ControllerPrivateAccessor(controller).span();

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -139,7 +139,7 @@ inline void PackSofaHeader(char* sofa_header, int meta_size, int body_size) {
 
 static void SerializeSofaHeaderAndMeta(
     butil::IOBuf* out, const SofaRpcMeta& meta, int payload_size) {
-    const int meta_size = meta.ByteSize();
+    const int meta_size = meta.ByteSizeLong();
     if (meta_size <= 232) { // most common cases
         char header_and_meta[24 + meta_size];
         PackSofaHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/streaming_rpc_protocol.cpp
+++ b/src/brpc/policy/streaming_rpc_protocol.cpp
@@ -43,7 +43,7 @@ void PackStreamMessage(butil::IOBuf* out,
                        const StreamFrameMeta &fm,
                        const butil::IOBuf *data) {
     const uint32_t data_length = data ? data->length() : 0;
-    const uint32_t meta_length = fm.ByteSize();
+    const uint32_t meta_length = fm.ByteSizeLong();
     char head[12];
     uint32_t* dummy = (uint32_t*)head;  // suppresses strict-alias warning
     *(uint32_t*)dummy = *(const uint32_t*)"STRM";


### PR DESCRIPTION
Fix build warning, protobuf ByteSize() is deprecated, use ByteSizeLong() instead