### PR TITLE
Fix LatencyRecorder qps not accurate

### DIFF
--- a/src/bvar/latency_recorder.cpp
+++ b/src/bvar/latency_recorder.cpp
@@ -89,14 +89,23 @@ int CDF::describe_series(
     return 0;
 }
 
+// Return random int value with expectation = `dval'
+static int64_t double_to_random_int(double dval) {
+    int64_t ival = static_cast<int64_t>(dval);
+    if (dval > ival + butil::fast_rand_double()) {
+        ival += 1;
+    }
+    return ival;
+}
+
 static int64_t get_window_recorder_qps(void* arg) {
     detail::Sample<Stat> s;
-    static_cast<RecorderWindow*>(arg)->get_span(1, &s);
+    static_cast<RecorderWindow*>(arg)->get_span(&s);
     // Use floating point to avoid overflow.
     if (s.time_us <= 0) {
         return 0;
     }
-    return static_cast<int64_t>(round(s.data.num * 1000000.0 / s.time_us));
+    return double_to_random_int(s.data.num * 1000000.0 / s.time_us);
 }
 
 static int64_t get_recorder_count(void* arg) {
@@ -176,7 +185,7 @@ int64_t LatencyRecorder::qps(time_t window_size) const {
     if (s.time_us <= 0) {
         return 0;
     }
-    return static_cast<int64_t>(round(s.data.num * 1000000.0 / s.time_us));
+    return detail::double_to_random_int(s.data.num * 1000000.0 / s.time_us);
 }
 
 int LatencyRecorder::expose(const butil::StringPiece& prefix1,

--- a/test/Makefile
+++ b/test/Makefile
@@ -189,7 +189,7 @@ clean_bins:
 libbrpc.dbg.$(SOEXT):FORCE
 	$(MAKE) -C.. test/libbrpc.dbg.$(SOEXT)
 
-libbvar.dbg.a:FORCE
+libbvar.dbg.a:libbrpc.dbg.$(SOEXT) FORCE
 	$(MAKE) -C.. test/libbvar.dbg.a
 
 FORCE:

--- a/test/bvar_recorder_unittest.cpp
+++ b/test/bvar_recorder_unittest.cpp
@@ -212,7 +212,7 @@ TEST(RecorderTest, latency_recorder_qps_accuracy) {
     bvar::LatencyRecorder lr2(2);
     bvar::LatencyRecorder lr3(2);
     bvar::LatencyRecorder lr4(2);
-    usleep(2000000); // wait sampler to sample 2 times
+    usleep(3000000); // wait sampler to sample 3 times
 
     auto write = [](bvar::LatencyRecorder& lr, int times) {   
         for (int i = 0; i < times; ++i) {

--- a/test/bvar_recorder_unittest.cpp
+++ b/test/bvar_recorder_unittest.cpp
@@ -206,4 +206,46 @@ TEST(RecorderTest, perf) {
               << "ns per sample with " << ARRAY_SIZE(threads) 
               << " threads";
 }
+
+TEST(RecorderTest, latency_recorder_qps_accuracy) {
+    bvar::LatencyRecorder lr1(2); // set windows size to 2s
+    bvar::LatencyRecorder lr2(2);
+    bvar::LatencyRecorder lr3(2);
+    bvar::LatencyRecorder lr4(2);
+    usleep(2000000); // wait sampler to sample 2 times
+
+    auto write = [](bvar::LatencyRecorder& lr, int times) {   
+        for (int i = 0; i < times; ++i) {
+            lr << 1;
+        }
+    };
+    write(lr1, 100);
+    write(lr2, 101);
+    write(lr3, 3);
+    write(lr4, 1);
+    usleep(1000000); // wait sampler to sample 1 time
+
+    auto read = [](bvar::LatencyRecorder& lr, double exp_qps, int window_size = 0) {
+        int64_t qps_sum = 0;
+        int64_t exp_qps_int = (int64_t)exp_qps;
+        for (int i = 0; i < 1000; ++i) {
+            int64_t qps = window_size ? lr.qps(window_size): lr.qps();
+            EXPECT_GE(qps, exp_qps_int - 1);
+            EXPECT_LE(qps, exp_qps_int + 1);
+            qps_sum += qps;
+        }
+        double err = fabs(qps_sum / 1000.0 - exp_qps);
+        return err;
+    };
+    ASSERT_GT(0.1, read(lr1, 100/2.0));
+    ASSERT_GT(0.1, read(lr2, 101/2.0));
+    ASSERT_GT(0.1, read(lr3, 3/2.0));
+    ASSERT_GT(0.1, read(lr4, 1/2.0));
+
+    ASSERT_GT(0.1, read(lr1, 100/3.0, 3));
+    ASSERT_GT(0.1, read(lr2, 101/3.0, 3));
+    ASSERT_GT(0.1, read(lr3, 3/3.0, 3));
+    ASSERT_GT(0.1, read(lr4, 1/3.0, 3));
+}
+
 } // namespace


### PR DESCRIPTION
LatencyRecorder里面的qps，get_window_recorder_qps 函数里面，static_cast<RecorderWindow*>(arg)->get_span(1, &s);  
get_span的windows是1的，这样有个问题，如果10s中采集一次，前5s的qps=1000，后5s的qps=0，那么得到的qps就是0。

另外就是get_span的window>1时，会出现qps可能取到小数，比如0.1，然后返回类型就是int64_t，这样就强转成0了，导致没数据。