### PR TITLE
Fix unstable UT link error

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -189,7 +189,7 @@ clean_bins:
 libbrpc.dbg.$(SOEXT):FORCE
 	$(MAKE) -C.. test/libbrpc.dbg.$(SOEXT)
 
-libbvar.dbg.a:FORCE
+libbvar.dbg.a:libbrpc.dbg.$(SOEXT) FORCE
 	$(MAKE) -C.. test/libbvar.dbg.a
 
 FORCE:


### PR DESCRIPTION
问题的原因是在test目录中make的时候，并行启动了两个make子进程：
<img width="489" alt="image" src="https://user-images.githubusercontent.com/3894631/156534370-e2bf5ded-ae85-48a3-8366-caae8dbc9675.png">
导致make的时候bvar下的源文件（如src/bvar/detail/sampler.dbg.o）可能存在并发编译写入同一个.dbg.o文件：
<img width="980" alt="image" src="https://user-images.githubusercontent.com/3894631/156534665-12e1e621-8ff1-48e2-a158-b0911782d1e1.png">
导致最终生成的libbvar.dbg.a缺乏符号：
<img width="916" alt="image" src="https://user-images.githubusercontent.com/3894631/156534771-f1841132-e20c-4610-bde2-e7e671c52dbe.png">
