### PR TITLE
Fix build warning, ByteSize() is deprecated, use ByteSizeLong() instead

### DIFF
--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -59,7 +59,7 @@ DEFINE_bool(baidu_protocol_use_fullname, true,
 // 5. Not supported: chunk_info
 
 // Pack header into `buf'
-inline void PackRpcHeader(char* rpc_header, int meta_size, int payload_size) {
+inline void PackRpcHeader(char* rpc_header, uint32_t meta_size, int payload_size) {
     uint32_t* dummy = (uint32_t*)rpc_header;  // suppress strict-alias warning
     *dummy = *(uint32_t*)"PRPC";
     butil::RawPacker(rpc_header + 4)
@@ -69,7 +69,11 @@ inline void PackRpcHeader(char* rpc_header, int meta_size, int payload_size) {
 
 static void SerializeRpcHeaderAndMeta(
     butil::IOBuf* out, const RpcMeta& meta, int payload_size) {
+    #if GOOGLE_PROTOBUF_VERSION >= 3010000
+    const uint32_t meta_size = meta.ByteSizeLong();
+    #else
     const int meta_size = meta.ByteSize();
+    #endif
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackRpcHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -69,7 +69,7 @@ inline void PackRpcHeader(char* rpc_header, uint32_t meta_size, int payload_size
 
 static void SerializeRpcHeaderAndMeta(
     butil::IOBuf* out, const RpcMeta& meta, int payload_size) {
-    const uint32_t meta_size = PROTOBUF_BYTE_SIZE(meta);
+    const uint32_t meta_size = get_protobuf_byte_size(meta);
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackRpcHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -69,7 +69,7 @@ inline void PackRpcHeader(char* rpc_header, uint32_t meta_size, int payload_size
 
 static void SerializeRpcHeaderAndMeta(
     butil::IOBuf* out, const RpcMeta& meta, int payload_size) {
-    const uint32_t meta_size = get_protobuf_byte_size(meta);
+    const uint32_t meta_size = GetProtobufByteSize(meta);
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackRpcHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -69,11 +69,7 @@ inline void PackRpcHeader(char* rpc_header, uint32_t meta_size, int payload_size
 
 static void SerializeRpcHeaderAndMeta(
     butil::IOBuf* out, const RpcMeta& meta, int payload_size) {
-    #if GOOGLE_PROTOBUF_VERSION >= 3010000
-    const uint32_t meta_size = meta.ByteSizeLong();
-    #else
-    const int meta_size = meta.ByteSize();
-    #endif
+    const uint32_t meta_size = PROTOBUF_BYTE_SIZE(meta);
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackRpcHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -142,7 +142,7 @@ private:
     const char* _stream;
 };
 
-inline void PackHuluHeader(char* hulu_header, int meta_size, int body_size) {
+inline void PackHuluHeader(char* hulu_header, uint32_t meta_size, int body_size) {
     uint32_t* dummy = reinterpret_cast<uint32_t*>(hulu_header); // suppress strict-alias warning
     *dummy = *reinterpret_cast<const uint32_t*>("HULU");
     HuluRawPacker rp(hulu_header + 4);
@@ -152,7 +152,11 @@ inline void PackHuluHeader(char* hulu_header, int meta_size, int body_size) {
 template <typename Meta>
 static void SerializeHuluHeaderAndMeta(
     butil::IOBuf* out, const Meta& meta, int payload_size) {
+    #if GOOGLE_PROTOBUF_VERSION >= 3010000
+    const uint32_t meta_size = meta.ByteSizeLong();
+    #else
     const int meta_size = meta.ByteSize();
+    #endif
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackHuluHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -152,11 +152,7 @@ inline void PackHuluHeader(char* hulu_header, uint32_t meta_size, int body_size)
 template <typename Meta>
 static void SerializeHuluHeaderAndMeta(
     butil::IOBuf* out, const Meta& meta, int payload_size) {
-    #if GOOGLE_PROTOBUF_VERSION >= 3010000
-    const uint32_t meta_size = meta.ByteSizeLong();
-    #else
-    const int meta_size = meta.ByteSize();
-    #endif
+    const uint32_t meta_size = PROTOBUF_BYTE_SIZE(meta);
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackHuluHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -152,7 +152,7 @@ inline void PackHuluHeader(char* hulu_header, uint32_t meta_size, int body_size)
 template <typename Meta>
 static void SerializeHuluHeaderAndMeta(
     butil::IOBuf* out, const Meta& meta, int payload_size) {
-    const uint32_t meta_size = get_protobuf_byte_size(meta);
+    const uint32_t meta_size = GetProtobufByteSize(meta);
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackHuluHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -152,7 +152,7 @@ inline void PackHuluHeader(char* hulu_header, uint32_t meta_size, int body_size)
 template <typename Meta>
 static void SerializeHuluHeaderAndMeta(
     butil::IOBuf* out, const Meta& meta, int payload_size) {
-    const uint32_t meta_size = PROTOBUF_BYTE_SIZE(meta);
+    const uint32_t meta_size = get_protobuf_byte_size(meta);
     if (meta_size <= 244) { // most common cases
         char header_and_meta[12 + meta_size];
         PackHuluHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/public_pbrpc_protocol.cpp
+++ b/src/brpc/policy/public_pbrpc_protocol.cpp
@@ -266,7 +266,11 @@ void PackPublicPbrpcRequest(butil::IOBuf* buf,
     nshead.magic_num = NSHEAD_MAGICNUM;
     snprintf(nshead.provider, sizeof(nshead.provider), "%s", PROVIDER);
     nshead.version = NSHEAD_VERSION;
+    #if GOOGLE_PROTOBUF_VERSION >= 3010000
+    nshead.body_len = pbreq.ByteSizeLong();
+    #else
     nshead.body_len = pbreq.ByteSize();
+    #endif
     buf->append(&nshead, sizeof(nshead));
 
     Span* span = ControllerPrivateAccessor(controller).span();

--- a/src/brpc/policy/public_pbrpc_protocol.cpp
+++ b/src/brpc/policy/public_pbrpc_protocol.cpp
@@ -266,7 +266,7 @@ void PackPublicPbrpcRequest(butil::IOBuf* buf,
     nshead.magic_num = NSHEAD_MAGICNUM;
     snprintf(nshead.provider, sizeof(nshead.provider), "%s", PROVIDER);
     nshead.version = NSHEAD_VERSION;
-    nshead.body_len = PROTOBUF_BYTE_SIZE(pbreq);
+    nshead.body_len = get_protobuf_byte_size(pbreq);
     buf->append(&nshead, sizeof(nshead));
 
     Span* span = ControllerPrivateAccessor(controller).span();

--- a/src/brpc/policy/public_pbrpc_protocol.cpp
+++ b/src/brpc/policy/public_pbrpc_protocol.cpp
@@ -266,7 +266,7 @@ void PackPublicPbrpcRequest(butil::IOBuf* buf,
     nshead.magic_num = NSHEAD_MAGICNUM;
     snprintf(nshead.provider, sizeof(nshead.provider), "%s", PROVIDER);
     nshead.version = NSHEAD_VERSION;
-    nshead.body_len = get_protobuf_byte_size(pbreq);
+    nshead.body_len = GetProtobufByteSize(pbreq);
     buf->append(&nshead, sizeof(nshead));
 
     Span* span = ControllerPrivateAccessor(controller).span();

--- a/src/brpc/policy/public_pbrpc_protocol.cpp
+++ b/src/brpc/policy/public_pbrpc_protocol.cpp
@@ -266,11 +266,7 @@ void PackPublicPbrpcRequest(butil::IOBuf* buf,
     nshead.magic_num = NSHEAD_MAGICNUM;
     snprintf(nshead.provider, sizeof(nshead.provider), "%s", PROVIDER);
     nshead.version = NSHEAD_VERSION;
-    #if GOOGLE_PROTOBUF_VERSION >= 3010000
-    nshead.body_len = pbreq.ByteSizeLong();
-    #else
-    nshead.body_len = pbreq.ByteSize();
-    #endif
+    nshead.body_len = PROTOBUF_BYTE_SIZE(pbreq);
     buf->append(&nshead, sizeof(nshead));
 
     Span* span = ControllerPrivateAccessor(controller).span();

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -129,7 +129,7 @@ private:
     const char* _stream;
 };
 
-inline void PackSofaHeader(char* sofa_header, int meta_size, int body_size) {
+inline void PackSofaHeader(char* sofa_header, uint32_t meta_size, int body_size) {
     uint32_t* dummy = reinterpret_cast<uint32_t*>(sofa_header); // suppress strict-alias warning
     *dummy = *reinterpret_cast<const uint32_t*>("SOFA");
 
@@ -139,7 +139,11 @@ inline void PackSofaHeader(char* sofa_header, int meta_size, int body_size) {
 
 static void SerializeSofaHeaderAndMeta(
     butil::IOBuf* out, const SofaRpcMeta& meta, int payload_size) {
+    #if GOOGLE_PROTOBUF_VERSION >= 3010000
+    const uint32_t meta_size = meta.ByteSizeLong();
+    #else
     const int meta_size = meta.ByteSize();
+    #endif
     if (meta_size <= 232) { // most common cases
         char header_and_meta[24 + meta_size];
         PackSofaHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -139,11 +139,7 @@ inline void PackSofaHeader(char* sofa_header, uint32_t meta_size, int body_size)
 
 static void SerializeSofaHeaderAndMeta(
     butil::IOBuf* out, const SofaRpcMeta& meta, int payload_size) {
-    #if GOOGLE_PROTOBUF_VERSION >= 3010000
-    const uint32_t meta_size = meta.ByteSizeLong();
-    #else
-    const int meta_size = meta.ByteSize();
-    #endif
+    const uint32_t meta_size = PROTOBUF_BYTE_SIZE(meta);
     if (meta_size <= 232) { // most common cases
         char header_and_meta[24 + meta_size];
         PackSofaHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -139,7 +139,7 @@ inline void PackSofaHeader(char* sofa_header, uint32_t meta_size, int body_size)
 
 static void SerializeSofaHeaderAndMeta(
     butil::IOBuf* out, const SofaRpcMeta& meta, int payload_size) {
-    const uint32_t meta_size = PROTOBUF_BYTE_SIZE(meta);
+    const uint32_t meta_size = get_protobuf_byte_size(meta);
     if (meta_size <= 232) { // most common cases
         char header_and_meta[24 + meta_size];
         PackSofaHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -139,7 +139,7 @@ inline void PackSofaHeader(char* sofa_header, uint32_t meta_size, int body_size)
 
 static void SerializeSofaHeaderAndMeta(
     butil::IOBuf* out, const SofaRpcMeta& meta, int payload_size) {
-    const uint32_t meta_size = get_protobuf_byte_size(meta);
+    const uint32_t meta_size = GetProtobufByteSize(meta);
     if (meta_size <= 232) { // most common cases
         char header_and_meta[24 + meta_size];
         PackSofaHeader(header_and_meta, meta_size, payload_size);

--- a/src/brpc/policy/streaming_rpc_protocol.cpp
+++ b/src/brpc/policy/streaming_rpc_protocol.cpp
@@ -43,7 +43,11 @@ void PackStreamMessage(butil::IOBuf* out,
                        const StreamFrameMeta &fm,
                        const butil::IOBuf *data) {
     const uint32_t data_length = data ? data->length() : 0;
+    #if GOOGLE_PROTOBUF_VERSION >= 3010000
+    const uint32_t meta_length = fm.ByteSizeLong();
+    #else
     const uint32_t meta_length = fm.ByteSize();
+    #endif
     char head[12];
     uint32_t* dummy = (uint32_t*)head;  // suppresses strict-alias warning
     *(uint32_t*)dummy = *(const uint32_t*)"STRM";

--- a/src/brpc/policy/streaming_rpc_protocol.cpp
+++ b/src/brpc/policy/streaming_rpc_protocol.cpp
@@ -43,7 +43,7 @@ void PackStreamMessage(butil::IOBuf* out,
                        const StreamFrameMeta &fm,
                        const butil::IOBuf *data) {
     const uint32_t data_length = data ? data->length() : 0;
-    const uint32_t meta_length = get_protobuf_byte_size(fm);
+    const uint32_t meta_length = GetProtobufByteSize(fm);
     char head[12];
     uint32_t* dummy = (uint32_t*)head;  // suppresses strict-alias warning
     *(uint32_t*)dummy = *(const uint32_t*)"STRM";

--- a/src/brpc/policy/streaming_rpc_protocol.cpp
+++ b/src/brpc/policy/streaming_rpc_protocol.cpp
@@ -43,7 +43,7 @@ void PackStreamMessage(butil::IOBuf* out,
                        const StreamFrameMeta &fm,
                        const butil::IOBuf *data) {
     const uint32_t data_length = data ? data->length() : 0;
-    const uint32_t meta_length = PROTOBUF_BYTE_SIZE(fm);
+    const uint32_t meta_length = get_protobuf_byte_size(fm);
     char head[12];
     uint32_t* dummy = (uint32_t*)head;  // suppresses strict-alias warning
     *(uint32_t*)dummy = *(const uint32_t*)"STRM";

--- a/src/brpc/policy/streaming_rpc_protocol.cpp
+++ b/src/brpc/policy/streaming_rpc_protocol.cpp
@@ -43,11 +43,7 @@ void PackStreamMessage(butil::IOBuf* out,
                        const StreamFrameMeta &fm,
                        const butil::IOBuf *data) {
     const uint32_t data_length = data ? data->length() : 0;
-    #if GOOGLE_PROTOBUF_VERSION >= 3010000
-    const uint32_t meta_length = fm.ByteSizeLong();
-    #else
-    const uint32_t meta_length = fm.ByteSize();
-    #endif
+    const uint32_t meta_length = PROTOBUF_BYTE_SIZE(fm);
     char head[12];
     uint32_t* dummy = (uint32_t*)head;  // suppresses strict-alias warning
     *(uint32_t*)dummy = *(const uint32_t*)"STRM";

--- a/src/brpc/protocol.h
+++ b/src/brpc/protocol.h
@@ -58,12 +58,15 @@ DECLARE_bool(log_error_text);
 
 // Get the serialized byte size of the protobuf message, 
 // different versions of protobuf have different methods
-
+// use template to avoid include `google/protobuf/message.h`
+template<typename T>
+inline uint32_t get_protobuf_byte_size(const T& message) {
 #if GOOGLE_PROTOBUF_VERSION >= 3010000
-#define PROTOBUF_BYTE_SIZE(message) ((message).ByteSizeLong())
+    return message.ByteSizeLong();
 #else
-#define PROTOBUF_BYTE_SIZE(message) (static_cast<uint32_t>((message).ByteSize()))
+    return static_cast<uint32_t>((message).ByteSize());
 #endif
+}
 
 // 3 steps to add a new Protocol:
 // Step1: Add a new ProtocolType in src/brpc/options.proto

--- a/src/brpc/protocol.h
+++ b/src/brpc/protocol.h
@@ -60,11 +60,11 @@ DECLARE_bool(log_error_text);
 // different versions of protobuf have different methods
 // use template to avoid include `google/protobuf/message.h`
 template<typename T>
-inline uint32_t get_protobuf_byte_size(const T& message) {
+inline uint32_t GetProtobufByteSize(const T& message) {
 #if GOOGLE_PROTOBUF_VERSION >= 3010000
     return message.ByteSizeLong();
 #else
-    return static_cast<uint32_t>((message).ByteSize());
+    return static_cast<uint32_t>(message.ByteSize());
 #endif
 }
 

--- a/src/brpc/protocol.h
+++ b/src/brpc/protocol.h
@@ -56,6 +56,15 @@ class InputMessageBase;
 DECLARE_uint64(max_body_size);
 DECLARE_bool(log_error_text);
 
+// Get the serialized byte size of the protobuf message, 
+// different versions of protobuf have different methods
+
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+#define PROTOBUF_BYTE_SIZE(message) ((message).ByteSizeLong())
+#else
+#define PROTOBUF_BYTE_SIZE(message) (static_cast<uint32_t>((message).ByteSize()))
+#endif
+
 // 3 steps to add a new Protocol:
 // Step1: Add a new ProtocolType in src/brpc/options.proto
 //        as identifier of the Protocol.


### PR DESCRIPTION
Fix build warning, protobuf ByteSize() is deprecated, use ByteSizeLong() instead