### PR TITLE
Redis empty request

### DIFF
--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -305,6 +305,11 @@ void SerializeRedisRequest(butil::IOBuf* buf,
         return cntl->SetFailed(EREQUEST, "The request is not a RedisRequest");
     }
     const RedisRequest* rr = (const RedisRequest*)request;
+    // If redis byte size is zero, brpc call will fail with E22. Continuous E22 may cause E112 in the end.
+    // So print warning log here as a notice
+    if(rr->ByteSize() == 0) {
+        LOG(WARNING) << "redis request is empty, please check the redis request content";
+    }
     // We work around SerializeTo of pb which is just a placeholder.
     if (!rr->SerializeTo(buf)) {
         return cntl->SetFailed(EREQUEST, "Fail to serialize RedisRequest");

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -307,7 +307,7 @@ void SerializeRedisRequest(butil::IOBuf* buf,
     const RedisRequest* rr = (const RedisRequest*)request;
     // If redis byte size is zero, brpc call will fail with E22. Continuous E22 may cause E112 in the end.
     // So set failed and return useful error message
-    if(rr->ByteSize() == 0) {
+    if (rr->ByteSize() == 0) {
         return cntl->SetFailed(EREQUEST, "request byte size is empty");
     }
     // We work around SerializeTo of pb which is just a placeholder.

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -306,9 +306,9 @@ void SerializeRedisRequest(butil::IOBuf* buf,
     }
     const RedisRequest* rr = (const RedisRequest*)request;
     // If redis byte size is zero, brpc call will fail with E22. Continuous E22 may cause E112 in the end.
-    // So print warning log here as a notice
+    // So set failed and return useful error message
     if(rr->ByteSize() == 0) {
-        LOG(WARNING) << "redis request is empty, please check the redis request content";
+        return cntl->SetFailed(EREQUEST, "request byte size is empty");
     }
     // We work around SerializeTo of pb which is just a placeholder.
     if (!rr->SerializeTo(buf)) {


### PR DESCRIPTION
issue: https://github.com/apache/incubator-brpc/issues/1743
in brpc redis protocol, set failed and return error message when byte size is empty in redis request.