### PR TITLE
fix auto https check

### DIFF
--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -295,7 +295,7 @@ int Channel::InitSingle(const butil::EndPoint& server_addr_and_port,
     if (raw_port != -1) {
         _service_name.append(":").append(std::to_string(raw_port));
     }
-    if (_options.protocol == brpc::PROTOCOL_HTTP && scheme == "https://") {
+    if (_options.protocol == brpc::PROTOCOL_HTTP && scheme == "https") {
         if (_options.mutable_ssl_options()->sni_name.empty()) {
             _options.mutable_ssl_options()->sni_name = _service_name;
         }
@@ -336,7 +336,7 @@ int Channel::Init(const char* ns_url,
     if (raw_port != -1) {
         _service_name.append(":").append(std::to_string(raw_port));
     }
-    if (_options.protocol == brpc::PROTOCOL_HTTP && scheme == "https://") {
+    if (_options.protocol == brpc::PROTOCOL_HTTP && scheme == "https") {
         if (_options.mutable_ssl_options()->sni_name.empty()) {
             _options.mutable_ssl_options()->sni_name = _service_name;
         }


### PR DESCRIPTION
[文章](https://github.com/apache/incubator-brpc/blob/master/docs/cn/client.md#%E5%BC%80%E5%90%AFssl) 文档中提到“Channel.Init能自动识别https”，相关功能在去年重构代码中引入了 bug，目前此功能已失效。这个 pt 是为了修复这个问题