### PR TITLE
client.md 文档优化

### DIFF
--- a/docs/cn/client.md
+++ b/docs/cn/client.md
@@ -731,7 +731,7 @@ options.mutable_ssl_options()->sni_name = "...";
 ```
 - 连接单点和集群的Channel均可以开启SSL访问（初始实现曾不支持集群）。
 - 开启后，该Channel上任何协议的请求，都会被SSL加密后发送。如果希望某些请求不加密，需要额外再创建一个Channel。
-- 针对HTTPS做了些易用性优化：Channel.Init能自动识别https:// 前缀并自动开启SSL；开启-http_verbose也会输出证书信息。
+- 针对HTTPS做了些易用性优化：Channel.Init能自动识别`https://`前缀并自动开启SSL；开启-http_verbose也会输出证书信息。
 
 ## 认证
 

--- a/docs/cn/client.md
+++ b/docs/cn/client.md
@@ -731,7 +731,7 @@ options.mutable_ssl_options()->sni_name = "...";
 ```
 - 连接单点和集群的Channel均可以开启SSL访问（初始实现曾不支持集群）。
 - 开启后，该Channel上任何协议的请求，都会被SSL加密后发送。如果希望某些请求不加密，需要额外再创建一个Channel。
-- 针对HTTPS做了些易用性优化：Channel.Init能自动识别https://前缀并自动开启SSL；开启-http_verbose也会输出证书信息。
+- 针对HTTPS做了些易用性优化：Channel.Init能自动识别https:// 前缀并自动开启SSL；开启-http_verbose也会输出证书信息。
 
 ## 认证
 


### PR DESCRIPTION
https:// 后面补一个空格，防止后面的中文被网页识别成链接的一部分，引起误解（以为是引用了其他文档）。当前网页上显示效果如下：

![77f2e94a54779bd7dd70e24269abe4e](https://user-images.githubusercontent.com/5945107/166116090-895e5a90-2b02-4726-8f5e-fcb236a9bc95.png)
