### PR TITLE
fix rpc_press can't send request equably

### DIFF
--- a/tools/rpc_press/rpc_press.cpp
+++ b/tools/rpc_press/rpc_press.cpp
@@ -71,6 +71,14 @@ bool set_press_options(pbrpcframework::PressOptions* options){
         }
     }
 
+    const int rate_limit_per_thread = 1000000;
+    double req_rate_per_thread = options->test_req_rate / options->test_thread_num;
+    if (req_rate_per_thread > rate_limit_per_thread) {
+        LOG(ERROR) << "req_rate: " << (int64_t) req_rate_per_thread << " is too large in one thread. The rate limit is " 
+                <<  rate_limit_per_thread << " in one thread";
+        return false;  
+    }
+
     options->input = FLAGS_input;
     options->output = FLAGS_output;
     options->connection_type = FLAGS_connection_type;

--- a/tools/rpc_press/rpc_press_impl.cpp
+++ b/tools/rpc_press/rpc_press_impl.cpp
@@ -22,7 +22,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <thread>
 #include <bthread/bthread.h>
 #include <butil/file_util.h>                     // butil::FilePath
 #include <butil/time.h>
@@ -245,7 +244,7 @@ void RpcPress::sync_client() {
             int64_t end_time = butil::monotonic_time_ns();
             int64_t expected_time = last_expected_time + interval;
             if (end_time < expected_time) {
-                std::this_thread::sleep_for(std::chrono::nanoseconds(expected_time - end_time));
+                usleep((expected_time - end_time)/1000);
             }
             last_expected_time = expected_time;
         }

--- a/tools/rpc_press/rpc_press_impl.cpp
+++ b/tools/rpc_press/rpc_press_impl.cpp
@@ -221,6 +221,8 @@ void RpcPress::sync_client() {
     int msg_index = thread_index;
     int64_t last_expected_time = butil::monotonic_time_ns();
     const int64_t interval = (int64_t) (1000000000L / req_rate);
+    // the max tolerant delay between end_time and expected_time. 10ms or 10 intervals
+    int64_t max_tolerant_delay = std::max(10000000L, 10 * interval);    
     while (!_stop) {
         brpc::Controller* cntl = new brpc::Controller;
         msg_index = (msg_index + _options.test_thread_num) % _msgs.size();
@@ -246,6 +248,9 @@ void RpcPress::sync_client() {
             if (end_time < expected_time) {
                 usleep((expected_time - end_time)/1000);
             }
+            if (end_time - expected_time > max_tolerant_delay) {
+                expected_time = end_time;
+            }            
             last_expected_time = expected_time;
         }
     }

--- a/tools/rpc_press/rpc_press_impl.cpp
+++ b/tools/rpc_press/rpc_press_impl.cpp
@@ -219,14 +219,8 @@ void RpcPress::sync_client() {
     }
     const int thread_index = g_thread_count.fetch_add(1, butil::memory_order_relaxed);
     int msg_index = thread_index;
-    std::deque<int64_t> timeq;
-    size_t MAX_QUEUE_SIZE = (size_t)req_rate;
-    if (MAX_QUEUE_SIZE < 100) {
-        MAX_QUEUE_SIZE = 100;
-    } else if (MAX_QUEUE_SIZE > 2000) {
-        MAX_QUEUE_SIZE = 2000;
-    }
-    timeq.push_back(butil::gettimeofday_us());
+    int64_t last_expected_time = butil::gettimeofday_us();
+    const int64_t interval = (int64_t) (1000000 / req_rate);
     while (!_stop) {
         brpc::Controller* cntl = new brpc::Controller;
         msg_index = (msg_index + _options.test_thread_num) % _msgs.size();
@@ -248,20 +242,11 @@ void RpcPress::sync_client() {
             brpc::Join(cid1);
         } else {
             int64_t end_time = butil::gettimeofday_us();
-            int64_t expected_elp = 0;
-            int64_t actual_elp = 0;
-            timeq.push_back(end_time);
-            if (timeq.size() > MAX_QUEUE_SIZE) {
-                actual_elp = end_time - timeq.front();
-                timeq.pop_front();
-                expected_elp = (int64_t)(1000000 * timeq.size() / req_rate);
-            } else {
-                actual_elp = end_time - timeq.front();
-                expected_elp = (int64_t)(1000000 * (timeq.size() - 1) / req_rate);
+            int64_t expected_time = last_expected_time + interval;
+            if (end_time < expected_time) {
+                usleep(expected_time - end_time);
             }
-            if (actual_elp < expected_elp) {
-                usleep(expected_elp - actual_elp);
-            }
+            last_expected_time = expected_time;
         }
     }
 }


### PR DESCRIPTION
项目中利用rpc_press进行压测，出现服务衰减问题，即压测过程中服务性能越变越差。后来通过分析发现rpc_press压测工具的实现存在问题，网络或者CPU抖动造成的发送请求不均匀会一直保存在窗口中，并影响后续请求，随程序运行时间变长，抖动出现的次数越来越多，发送地请求会越来越不均匀。具体分析如下：

举例说明：假设 QPS: 100，异步发送请求平均耗时 1ms，为方便画图，假设队列最大长度为10。

图(1) 中发送编号为4的请求时CPU或者网络抖动，造成本应在t+31发出的请求滞后了15ms，按照代码逻辑，编号为5/6的请求分别在t + 47 和 t + 51发出

图(2) 我们假设队列最大长度为10，按照图上的计算过程可以得到，发送完请求14后会sleep 24ms，这样就导致发送请求4时的抖动，对请求15发送时间造成了影响，抖动会在队列中一直存在。QPS越高，请求间隔越短，这个问题越容易出现。
![image](https://user-images.githubusercontent.com/20112368/168551374-00991c77-c6a8-4bf5-9cc3-d6c623de0e12.png)
本pull request利用一种更简单的方式来计算请求间隔，来解决上述问题。
