### PR TITLE
Fix a deadlock happened in ClearAbandonedStreamsImpl path(issues/1778)

### DIFF
--- a/src/brpc/policy/http2_rpc_protocol.h
+++ b/src/brpc/policy/http2_rpc_protocol.h
@@ -370,11 +370,11 @@ friend void InitFrameHandlers();
     H2ParseResult OnWindowUpdate(butil::IOBufBytesIterator&, const H2FrameHead&);
     H2ParseResult OnContinuation(butil::IOBufBytesIterator&, const H2FrameHead&);
 
+    H2StreamContext* RemoveStreamAndDeferWU(int stream_id);
     H2StreamContext* RemoveStream(int stream_id);
     void RemoveGoAwayStreams(int goaway_stream_id, std::vector<H2StreamContext*>* out_streams);
 
     H2StreamContext* FindStream(int stream_id);
-    void ClearAbandonedStreamsImpl();
 
     // True if the connection is established by client, otherwise it's
     // accepted by server.


### PR DESCRIPTION
Change:
* Fix a deadlock
* Rename RemoveStream to RemoveStreamAndDeferWU and change the impl of original RemoveStreamAndDeferWU
* Remove ClearAbandonedStreamsImpl because it reads protected vars without lock