### PR TITLE
BugFix: Send WindowUpdate when ClearAbandonedStreams is called

### DIFF
--- a/src/brpc/policy/http2_rpc_protocol.h
+++ b/src/brpc/policy/http2_rpc_protocol.h
@@ -371,7 +371,6 @@ friend void InitFrameHandlers();
     H2ParseResult OnContinuation(butil::IOBufBytesIterator&, const H2FrameHead&);
 
     H2StreamContext* RemoveStreamAndDeferWU(int stream_id);
-    H2StreamContext* RemoveStream(int stream_id);
     void RemoveGoAwayStreams(int goaway_stream_id, std::vector<H2StreamContext*>* out_streams);
 
     H2StreamContext* FindStream(int stream_id);


### PR DESCRIPTION
Follow-up of https://github.com/apache/incubator-brpc/pull/1781

在ClearAbandonedStreams的时候更新Windowsize，否则这些streams消耗的windowsize无法正确复原。原issue中的死锁问题已通过在ClearAbandonedStreams调用RemoveStreamAndDeferWU前，释放锁的方式解决。