### PR TITLE
Fix Brpc build tools error when only build static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(DEBUG "Print debug logs" OFF)
 option(WITH_DEBUG_SYMBOLS "With debug symbols" ON)
 option(WITH_THRIFT "With thrift framed protocol supported" OFF)
 option(BUILD_UNIT_TESTS "Whether to build unit tests" OFF)
+option(BUILD_BRPC_TOOLS "Whether to build brpc tools" ON)
 option(DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." ON)
 
 # Enable MACOSX_RPATH. Run "cmake --help-policy CMP0042" for policy details.
@@ -31,7 +32,7 @@ if(POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
 endif()
 
-set(BRPC_VERSION 0.9.0)
+set(BRPC_VERSION 1.1.0)
 
 SET(CPACK_GENERATOR "DEB")
 SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "brpc authors")
@@ -434,7 +435,10 @@ if(BUILD_UNIT_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()
-add_subdirectory(tools)
+
+if(BUILD_BRPC_TOOLS)
+    add_subdirectory(tools)
+endif()
 
 file(COPY ${CMAKE_CURRENT_BINARY_DIR}/brpc/
         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/output/include/brpc/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,15 +58,18 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
 set(protoc_gen_mcpack_SOURCES
     ${PROJECT_SOURCE_DIR}/src/mcpack2pb/generator.cpp
  )
-add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
-target_link_libraries(protoc-gen-mcpack brpc-shared)
     
 #install directory
-install(TARGETS brpc-shared
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
+if(BUILD_SHARED_LIBS)
+    add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
+    target_link_libraries(protoc-gen-mcpack brpc-shared)
+
+    install(TARGETS brpc-shared
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            )
+endif()
 
 install(TARGETS brpc-static
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if(BUILD_SHARED_LIBS)
     endif()
     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 
-    target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB} pthread ldl)
+    target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB} pthread)
 
     install(TARGETS brpc-shared
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if(BUILD_SHARED_LIBS)
     endif()
     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 
-    target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB})
+    target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB} pthread ldl)
 
     install(TARGETS brpc-shared
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,26 +31,15 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
 set_property(TARGET ${SOURCES_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
 set_property(TARGET ${BUTIL_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
 
-add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> 
-                               $<TARGET_OBJECTS:SOURCES_LIB>
-                               $<TARGET_OBJECTS:PROTO_LIB>)
 add_library(brpc-static STATIC $<TARGET_OBJECTS:BUTIL_LIB>
                                $<TARGET_OBJECTS:SOURCES_LIB>
                                $<TARGET_OBJECTS:PROTO_LIB>)
 
-target_link_libraries(brpc-shared ${DYNAMIC_LIB})
-
-if(BRPC_WITH_GLOG)
-    target_link_libraries(brpc-shared ${GLOG_LIB})
-endif()
-
 if(BRPC_WITH_THRIFT)
-    target_link_libraries(brpc-shared thrift)
-    target_link_libraries(brpc-static thrift)
+   target_link_libraries(brpc-static thrift)
 endif()
 
 SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
-SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 
 # for protoc-gen-mcpack
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
@@ -59,9 +48,21 @@ set(protoc_gen_mcpack_SOURCES
     ${PROJECT_SOURCE_DIR}/src/mcpack2pb/generator.cpp
  )
     
-#install directory
+add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
+
 if(BUILD_SHARED_LIBS)
-    add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
+    add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> 
+                                   $<TARGET_OBJECTS:SOURCES_LIB>
+                                   $<TARGET_OBJECTS:PROTO_LIB>)
+    target_link_libraries(brpc-shared ${DYNAMIC_LIB})
+    if(BRPC_WITH_GLOG)
+        target_link_libraries(brpc-shared ${GLOG_LIB})
+    endif()
+    if(BRPC_WITH_THRIFT)
+        target_link_libraries(brpc-shared thrift)
+    endif()
+    SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
+
     target_link_libraries(protoc-gen-mcpack brpc-shared)
 
     install(TARGETS brpc-shared
@@ -69,7 +70,11 @@ if(BUILD_SHARED_LIBS)
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )
+else()
+    target_link_libraries(protoc-gen-mcpack brpc-static ${BRPC_PRIVATE_LIBS})
 endif()
+
+
 
 install(TARGETS brpc-static
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if(BUILD_SHARED_LIBS)
     endif()
     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 
-    target_link_libraries(protoc-gen-mcpack brpc-shared)
+    target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB})
 
     install(TARGETS brpc-shared
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if(BUILD_SHARED_LIBS)
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )
 else()
-    target_link_libraries(protoc-gen-mcpack brpc-static ${BRPC_PRIVATE_LIBS})
+    target_link_libraries(protoc-gen-mcpack brpc-static ${BRPC_PRIVATE_LIBS} pthread ldl)
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if(BUILD_SHARED_LIBS)
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )
 else()
-    target_link_libraries(protoc-gen-mcpack brpc-static ${BRPC_PRIVATE_LIBS} pthread ldl)
+    target_link_libraries(protoc-gen-mcpack brpc-static ${BRPC_PRIVATE_LIBS} pthread)
 endif()
 
 


### PR DESCRIPTION
protoc-gen-mcpack dependent on shared libraries. so when I build with `-DBUILD_SHARED_LIBS=OFF`. I'll got a link error