### PR TITLE
support handle on_received_messages failure of streaming rpc

### DIFF
--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -462,8 +462,12 @@ public:
     ~MessageBatcher() { flush(); }
     void flush() {
         if (_size > 0 && _s->_options.handler != NULL) {
-            _s->_options.handler->on_received_messages(
+            int ret = _s->_options.handler->on_received_messages(
                     _s->id(), _storage, _size);
+            if (BAIDU_UNLIKELY(ret != 0)) {
+                LOG(WARNING) << "Fail to receive message for stream: " << _s->id();
+                _s->_options.handler->on_failure(_s->id());
+            }
         }
         for (size_t i = 0; i < _size; ++i) {
             delete _storage[i];

--- a/src/brpc/stream.h
+++ b/src/brpc/stream.h
@@ -45,6 +45,7 @@ public:
                                      size_t size) = 0;
     virtual void on_idle_timeout(StreamId id) = 0;
     virtual void on_closed(StreamId id) = 0; 
+    virtual void on_failure(StreamId id) {}
 };
 
 struct StreamOptions {


### PR DESCRIPTION
closed #1803 

support handle `on_received_messages` failure of streaming rpc, user can overload `on_failure` of `StreamInputHandler`  to handle `on_received_messages` failure,  the default is do nothing