### PR TITLE
CI: disable unstable MesaLink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ install:
 - sudo apt-get install -qq realpath libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev libgoogle-perftools-dev libboost-dev libssl-dev libevent-dev libboost-test-dev libgoogle-glog-dev
 - sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo env "PATH=$PATH" cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
 - sudo apt-get install -y gdb  # install gdb
-- wget https://mesalink.s3-us-west-1.amazonaws.com/MesaLink-1.0.0-x86_64_trusty.deb && sudo dpkg -i MesaLink-1.0.0-x86_64_trusty.deb # install MesaLink for trusty
 
 script:
 - sh build_in_travis_ci.sh

--- a/build_in_travis_ci.sh
+++ b/build_in_travis_ci.sh
@@ -56,11 +56,11 @@ elif [ "$PURPOSE" = "compile-with-cmake" ]; then
 elif [ "$PURPOSE" = "compile-with-bazel" ]; then
     bazel build -j 12 -c opt --copt -DHAVE_ZLIB=1 //...
 elif [ "$PURPOSE" = "compile-with-make-all-options" ]; then
-    init_make_config "--with-thrift --with-glog --with-mesalink" && make -j4
+    init_make_config "--with-thrift --with-glog" && make -j4
 elif [ "$PURPOSE" = "compile-with-cmake-all-options" ]; then
-    rm -rf bld && mkdir bld && cd bld && cmake -DWITH_MESALINK=ON -DWITH_GLOG=ON -DWITH_THRIFT=ON .. && make -j4
+    rm -rf bld && mkdir bld && cd bld && cmake -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON .. && make -j4
 elif [ "$PURPOSE" = "compile-with-bazel-all-options" ]; then
-    bazel build -j 12 -c opt --define with_mesalink=true --define with_glog=true --define with_thrift=true --copt -DHAVE_ZLIB=1 //...
+    bazel build -j 12 -c opt --define with_mesalink=false --define with_glog=true --define with_thrift=true --copt -DHAVE_ZLIB=1 //...
 else
     echo "Unknown purpose=\"$PURPOSE\""
 fi


### PR DESCRIPTION
MesaLink deb 下载地址不可用, 也未找到其他官方可替代地址. 由于 MesaLink 声明和 OpenSSL 兼容, 集成到 CI 中进行测试不是必须的.