### PR TITLE
fix hostname2ip fails when aux_buf is not long enough

### DIFF
--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -32,7 +32,6 @@
 #include "butil/logging.h"
 #include "butil/memory/singleton_on_pthread_once.h"
 #include "butil/strings/string_piece.h"
-#include "brpc/log.h"
 #include <sys/socket.h>                        // SO_REUSEADDR SO_REUSEPORT
 #include <memory>
 
@@ -211,17 +210,8 @@ int hostname2ip(const char* hostname, ip_t* ip) {
         }
         aux_buf_len *= 2;
         aux_buf.reset(new char[aux_buf_len]);
-        RPC_VLOG << "Resized aux_buf to " << aux_buf_len
-                 << ", hostname=" << hostname;
     } while (1);
-    if (ret != 0) {
-        // `hstrerror' is thread safe under linux
-        LOG(WARNING) << "Can't resolve `" << hostname << "', return=`" << berror(ret)
-                     << "' herror=`" << hstrerror(error) << '\'';
-        return -1;
-    }
-    if (result == NULL) {
-        LOG(WARNING) << "result of gethostbyname_r is NULL";
+    if (ret != 0 || result == NULL) {
         return -1;
     }
 #endif // defined(OS_MACOSX)

--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -203,8 +203,12 @@ int hostname2ip(const char* hostname, ip_t* ip) {
     do {
         result = NULL;
         error = 0;
-        ret = gethostbyname_r(hostname, &ent, aux_buf.get(), aux_buf_len,
-            &result, &error);
+        ret = gethostbyname_r(hostname,
+                              &ent,
+                              aux_buf.get(),
+                              aux_buf_len,
+                              &result,
+                              &error);
         if (ret != ERANGE) { // aux_buf is not long enough
             break;
         }

--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>                            // strtol
 #include <sys/un.h>                            // sockaddr_un
 #include <sys/socket.h>                        // SO_REUSEADDR SO_REUSEPORT
-#include <memory>
+#include <memory>                              // unique_ptr
 #include <gflags/gflags.h>
 #include "butil/build_config.h"                // OS_MACOSX
 #include "butil/fd_guard.h"                    // fd_guard

--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>                            // strtol
 #include <sys/un.h>                            // sockaddr_un
 #include <sys/socket.h>                        // SO_REUSEADDR SO_REUSEPORT
-#include <memory>                              // unique_ptr
+#include <memory>
 #include <gflags/gflags.h>
 #include "butil/build_config.h"                // OS_MACOSX
 #include "butil/fd_guard.h"                    // fd_guard

--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -17,7 +17,6 @@
 
 // Date: Mon. Nov 7 14:47:36 CST 2011
 
-#include "butil/build_config.h"                // OS_MACOSX
 #include <arpa/inet.h>                         // inet_pton, inet_ntop
 #include <netdb.h>                             // gethostbyname_r
 #include <unistd.h>                            // gethostname
@@ -26,14 +25,15 @@
 #include <stdio.h>                             // snprintf
 #include <stdlib.h>                            // strtol
 #include <sys/un.h>                            // sockaddr_un
+#include <sys/socket.h>                        // SO_REUSEADDR SO_REUSEPORT
+#include <memory>
 #include <gflags/gflags.h>
+#include "butil/build_config.h"                // OS_MACOSX
 #include "butil/fd_guard.h"                    // fd_guard
 #include "butil/endpoint.h"                    // ip_t
 #include "butil/logging.h"
 #include "butil/memory/singleton_on_pthread_once.h"
 #include "butil/strings/string_piece.h"
-#include <sys/socket.h>                        // SO_REUSEADDR SO_REUSEPORT
-#include <memory>
 
 //supported since Linux 3.9.
 DEFINE_bool(reuse_port, false, "Enable SO_REUSEPORT for all listened sockets");


### PR DESCRIPTION
使用Channel::Init("http://hostname", options)时，会在hostname2ip中通过gethostbyname_r获取dns的节点信息。如果hostname在dns中配置了很多节点，hostname2ip会因为aux_buf长度不够导致调用失败，从而导致Channel::Init失败。

解决方法：参考DomainNamingService获取节点信息的方法，当gethostbyname_r返回ERANGE，表示aux_buf长度不足时，将aux_buf长度增大一倍，重新调用gethostbyname_r获取节点信息，直到获取成功为止。