### PR TITLE
Fix stream will respond received feedback frame with RST frame when closed

### DIFF
--- a/src/brpc/policy/streaming_rpc_protocol.cpp
+++ b/src/brpc/policy/streaming_rpc_protocol.cpp
@@ -108,7 +108,9 @@ ParseResult ParseStreamingMessage(butil::IOBuf* source,
                             && fm.frame_type() != FRAME_TYPE_CLOSE
                             && fm.frame_type() != FRAME_TYPE_FEEDBACK)
                    << "Fail to find stream=" << fm.stream_id();
-            if (fm.has_source_stream_id()) {
+            // It's normal that the stream is closed before receiving feedback frames from peer.
+            // In this case, RST frame should not be sent to peer, otherwise on-fly data can be lost.
+            if (fm.has_source_stream_id() && fm.frame_type() != FRAME_TYPE_FEEDBACK) {
                 SendStreamRst(socket, fm.source_stream_id());
             }
             break;


### PR DESCRIPTION
## 问题
我们发现通过Streaming RPC协议发送数据存在丢失数据的可能，以下是丢失的过程：
假设两个进程通过brpc stream通信，我们把发送数据的进程称为sender，接受数据的进程为receiver。
1. sender连续三次调用StreamWrite，发送了三次数据，分别为A，B，C；然后调用StreamClose；
2. receiver收到sender的数据帧A之后，返回FEEDBACK数据帧给sender；
3. sender收到数据帧A对应的FEEDBACK，但是因为对应stream_id在步骤1调用完StreamClose后已经没有办法通过Socket::Address获取到，找不到stream_id对应的stream于是sender返回RST给receiver（调用SendStreamRst）; 
```cpp
/// streaming_rpc_protocol.cpp 106 行
if (Socket::Address((SocketId)fm.stream_id(), &ptr) != 0) {
    RPC_VLOG_IF(fm.frame_type() != FRAME_TYPE_RST
                && fm.frame_type() != FRAME_TYPE_CLOSE
                && fm.frame_type() != FRAME_TYPE_FEEDBACK)
    << "Fail to find stream=" << fm.stream_id();
    if (fm.has_source_stream_id()) {
        SendStreamRst(socket, fm.source_stream_id());
    }
    break;
}
```
4.  RST是直接通过sender的HostSocket写出，而步骤1中数据B和C则是通过一个fake_socket间接通过HostSocket写出，由于fake_socket写出可能由新起的协程完成（KeepWrite），存在可能RST反而比数据B或者C先写出；
5.  receiver接收到RST，会主动Close对应的Stream，于是on-fly的数据B和C如果比RST后写出就会丢失；

## 修复
按设计调用StreamClose后之前调用StreamWrite发送的数据都会正常接收，现在的行为不符合设计。为了修复上面的问题，
sender进程接收到feedback找不到对应的stream后，不再返回RST给对端，因为feedback找不到stream的情况很正常（调用StreamWrite后再调用StreamClose就有可能出现）。
```cpp
if (fm.has_source_stream_id() && fm.frame_type() != FRAME_TYPE_FEEDBACK) {
    SendStreamRst(socket, fm.source_stream_id());
}
```
当stream引用归零时（准确的说是stream所在的fake_socket)，在BeforeRecycle会给对端发送CLOSE，也会正常关闭对端，可以不需要通过RST关闭，虽然比用RST略晚，但FEEDBACK对应的stream已经close，不会写出新的数据，整体影响很小。

修复上线后丢失数据现象再也没有出现，也没有副作用出现，可以确认修复有效。如果分析和修复方法有考虑不周之处，或者有更好的方案欢迎指出。

