### PR TITLE
Fixing compilation in rpc_press, and fixing typo in execution-queue

### DIFF
--- a/src/bthread/execution_queue.cpp
+++ b/src/bthread/execution_queue.cpp
@@ -72,7 +72,7 @@ void ExecutionQueueBase::start_execute(TaskNode* node) {
     if (node->high_priority) {
         // Add _high_priority_tasks before pushing this task into queue to
         // make sure that _execute_tasks sees the newest number when this 
-        // task is in the queue. Althouth there might be some useless for 
+        // task is in the queue. Although there might be some useless for 
         // loops in _execute_tasks if this thread is scheduled out at this 
         // point, we think it's just fine.
         _high_priority_tasks.fetch_add(1, butil::memory_order_relaxed);
@@ -321,7 +321,7 @@ ExecutionQueueBase::scoped_ptr_t ExecutionQueueBase::address(uint64_t id) {
                         // We don't return m immediatly when the reference count
                         // reaches 0 as there might be in processing tasks. Instead
                         // _on_recycle would push a `stop_task', after which
-                        // is excuted m would be finally reset and returned
+                        // is executed m would be finally reset and returned
                     }
                 } else {
                     CHECK(false) << "ref-version=" << ver1

--- a/src/bthread/execution_queue.h
+++ b/src/bthread/execution_queue.h
@@ -198,7 +198,7 @@ int execution_queue_execute(ExecutionQueueId<T> id,
                             const TaskOptions* options,
                             TaskHandle* handle);
 
-// [Thread safe and ABA free] Cancel the corrosponding task.
+// [Thread safe and ABA free] Cancel the corresponding task.
 // Returns:
 //  -1: The task was executed or h is an invalid handle
 //  0: Success

--- a/src/bthread/execution_queue_inl.h
+++ b/src/bthread/execution_queue_inl.h
@@ -520,7 +520,7 @@ inline int ExecutionQueueBase::dereference() {
                 _on_recycle();
                 // We don't return m immediatly when the reference count
                 // reaches 0 as there might be in processing tasks. Instead
-                // _on_recycle would push a `stop_task' after which is excuted
+                // _on_recycle would push a `stop_task' after which is executed
                 // m would be finally returned and reset
                 return 1;
             }

--- a/tools/rpc_press/rpc_press_impl.cpp
+++ b/tools/rpc_press/rpc_press_impl.cpp
@@ -222,7 +222,7 @@ void RpcPress::sync_client() {
     int64_t last_expected_time = butil::monotonic_time_ns();
     const int64_t interval = (int64_t) (1000000000L / req_rate);
     // the max tolerant delay between end_time and expected_time. 10ms or 10 intervals
-    int64_t max_tolerant_delay = std::max(10000000L, 10 * interval);    
+    int64_t max_tolerant_delay = std::max((int64_t) 10000000L, 10 * interval);    
     while (!_stop) {
         brpc::Controller* cntl = new brpc::Controller;
         msg_index = (msg_index + _options.test_thread_num) % _msgs.size();


### PR DESCRIPTION
When compiling `rpc_press` using Apple M1 Pro and clang14, `std::max(10000000L, 10 * interval);` tells that `long` and `long long` conflict, so I change it to `10000000LL`, which represents "long long".

Also, I fix some typos in execution-queue mod.