### PR TITLE
support customized server bvar prefix

### DIFF
--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -271,7 +271,11 @@ static bvar::Vector<unsigned, 2> GetSessionLocalDataCount(void* arg) {
 }
 
 std::string Server::ServerPrefix() const {
-    return butil::string_printf("%s_%d", g_server_info_prefix, listen_address().port);
+    if(_options.server_info_name.empty()) {
+        return butil::string_printf("%s_%d", g_server_info_prefix, listen_address().port);
+    } else {
+        return std::string(g_server_info_prefix) + "_" + _options.server_info_name;
+    }
 }
 
 void* Server::UpdateDerivedVars(void* arg) {

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -241,6 +241,10 @@ struct ServerOptions {
     // Default: NULL (disabled)
     RedisService* redis_service;
 
+    // Optional info name for composing server bvar prefix. Read ServerPrefix() method for details;
+    // Default: ""
+    std::string server_info_name;
+
 private:
     // SSLOptions is large and not often used, allocate it on heap to
     // prevent ServerOptions from being bloated in most cases.


### PR DESCRIPTION
通过ServerOption自定义Server的Bvar prefix。
目前bvar默认的前缀是rpc_server_{server监听的port}，但是存在如下问题：
1. 由于port改变（如使用range port或者其他port可能会改变的场景)导致bvar name变化，使得配置的dashboard和监控失效
2. 为了支持IPV6和Unix Domain socket，引入了ExtendedEndPoint，不过生成prefix存在BUG，会固定用EXTENDED_ENDPOINT_PORT（123456789）生成前缀（rpc_server_123456789），导致不同的Server bvar前缀相同。虽然修复不难，但是Unix Domain socket不太好处理，因为没有port信息，如果用file_path的话又太长。

基于以上考虑，最好还是用户通过ServerOption传入Server name生成prefix，如果name为空，则保持原来的逻辑。