### PR TITLE
fix the first bthread keytable on worker pthread will be deleted twice

### DIFF
--- a/src/bthread/key.cpp
+++ b/src/bthread/key.cpp
@@ -446,10 +446,14 @@ int bthread_setspecific(bthread_key_t key, void* data) {
         bthread::TaskGroup* const g = bthread::tls_task_group;
         if (g) {
             g->current_task()->local_storage.keytable = kt;
-        }
-        if (!bthread::tls_ever_created_keytable) {
-            bthread::tls_ever_created_keytable = true;
-            CHECK_EQ(0, butil::thread_atexit(bthread::cleanup_pthread, kt));
+        } else {
+            // Only cleanup keytable created by pthread.
+            // keytable created by bthread will be deleted
+            // in `return_keytable' or `bthread_keytable_pool_destroy'.
+            if (!bthread::tls_ever_created_keytable) {
+                bthread::tls_ever_created_keytable = true;
+                CHECK_EQ(0, butil::thread_atexit(bthread::cleanup_pthread, kt));
+            }
         }
     }
     return kt->set_data(key, data);


### PR DESCRIPTION
fix #1714 
优雅退出时能只清理pthread创建的keytable，bthread创建的keytable不需要在cleanup_pthread中清理，这些keytable会在return_keytable或者bthread_keytable_pool_destroy中清理。