### PR TITLE
fix compile warning

### DIFF
--- a/src/bvar/mvariable.h
+++ b/src/bvar/mvariable.h
@@ -30,7 +30,7 @@
 namespace bvar {
 
 class Dumper;
-class DumpOptions;
+struct DumpOptions;
 
 class MVariable {
 public:


### PR DESCRIPTION
warning: class 'DumpOptions' was previously declared as a struct