### PR TITLE
解决protobuf 3.21编译失败的问题

### DIFF
--- a/src/brpc/esp_message.h
+++ b/src/brpc/esp_message.h
@@ -58,7 +58,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     EspMessage* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from);
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const EspMessage& from);
     void MergeFrom(const EspMessage& from);

--- a/src/brpc/esp_message.h
+++ b/src/brpc/esp_message.h
@@ -58,7 +58,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     EspMessage* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const EspMessage& from);
     void MergeFrom(const EspMessage& from);

--- a/src/brpc/memcache.h
+++ b/src/brpc/memcache.h
@@ -207,7 +207,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     MemcacheResponse* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const MemcacheResponse& from);
     void MergeFrom(const MemcacheResponse& from);

--- a/src/brpc/memcache.h
+++ b/src/brpc/memcache.h
@@ -94,7 +94,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     MemcacheRequest* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const MemcacheRequest& from);
     void MergeFrom(const MemcacheRequest& from);

--- a/src/brpc/nshead_message.h
+++ b/src/brpc/nshead_message.h
@@ -54,7 +54,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     NsheadMessage* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const NsheadMessage& from);
     void MergeFrom(const NsheadMessage& from);

--- a/src/brpc/nshead_message.h
+++ b/src/brpc/nshead_message.h
@@ -54,7 +54,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     NsheadMessage* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from);
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const NsheadMessage& from);
     void MergeFrom(const NsheadMessage& from);

--- a/src/brpc/pb_compat.h
+++ b/src/brpc/pb_compat.h
@@ -19,6 +19,12 @@
 #ifndef BRPC_PB_COMPAT_H
 #define BRPC_PB_COMPAT_H
 
+#if GOOGLE_PROTOBUF_VERSION < 3021000
+# define PB_321_OVERRIDE override
+#else
+# define PB_321_OVERRIDE
+#endif
+
 #if GOOGLE_PROTOBUF_VERSION < 3019000
 # define PB_319_OVERRIDE override
 #else

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -112,7 +112,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     RedisRequest* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const RedisRequest& from);
     void MergeFrom(const RedisRequest& from);
@@ -185,7 +185,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     RedisResponse* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from);
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const RedisResponse& from);
     void MergeFrom(const RedisResponse& from);

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -112,7 +112,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     RedisRequest* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from);
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const RedisRequest& from);
     void MergeFrom(const RedisRequest& from);
@@ -185,7 +185,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     RedisResponse* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from);
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void MergeFrom(const ::google::protobuf::Message& from) override;
     void CopyFrom(const RedisResponse& from);
     void MergeFrom(const RedisResponse& from);

--- a/src/brpc/serialized_request.h
+++ b/src/brpc/serialized_request.h
@@ -48,7 +48,7 @@ public:
 #if GOOGLE_PROTOBUF_VERSION >= 3006000
     SerializedRequest* New(::google::protobuf::Arena* arena) const override;
 #endif
-    void CopyFrom(const ::google::protobuf::Message& from) override;
+    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
     void CopyFrom(const SerializedRequest& from);
     void Clear() override;
     bool IsInitialized() const override;


### PR DESCRIPTION
当前master编译失败：
>./src/brpc/redis.h:115:60: error: only virtual member functions can be marked 'override'
    void CopyFrom(const ::google::protobuf::Message& from) override;
                                                           ^~~~~~~~
./src/brpc/redis.h:188:60: error: only virtual member functions can be marked 'override'
    void CopyFrom(const ::google::protobuf::Message& from) override;
                                                           ^~~~~~~~
In file included from src/brpc/esp_message.cpp:18:
src/brpc/esp_message.h:61:60: error: only virtual member functions can be marked 'override'
    void CopyFrom(const ::google::protobuf::Message& from) override;