### PR TITLE
bvar_dump_tabs默认值的问题

### DIFF
--- a/src/bvar/variable.cpp
+++ b/src/bvar/variable.cpp
@@ -705,9 +705,9 @@ DEFINE_string(bvar_dump_exclude, "", "Dump bvar excluded from these wildcards, "
               "separated by semicolon(;), empty means no exclusion");
 DEFINE_string(bvar_dump_prefix, "<app>", "Every dumped name starts with this prefix");
 DEFINE_string(bvar_dump_tabs, "latency=*_latency*"
-                              "; qps=*_qps*"
-                              "; error=*_error*"
-                              "; system=*process_*,*malloc_*,*kernel_*",
+                              ";qps=*_qps*"
+                              ";error=*_error*"
+                              ";system=*process_*,*malloc_*,*kernel_*",
               "Dump bvar into different tabs according to the filters (seperated by semicolon), "
               "format: *(tab_name=wildcards;)");
 


### PR DESCRIPTION
bvar_dump_tabs默认值包含空格，导致创建的文件名字里有空格。
个人感觉也没有必要trim一下，严格要求不包含空格就行。