### PR TITLE
[document] Add vcpkg instruction step

### DIFF
--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -170,6 +170,17 @@ $ sh run_tests.sh
 ### 使用cmake编译brpc
 参考[这里](#使用cmake编译brpc)
 
+### 使用vcpkg编译brpc
+
+[vcpkg](https://github.com/microsoft/vcpkg) 是一个全平台支持的包管理器，你可以使用以下步骤vcpkg轻松编译brpc:
+
+```shell
+$ git clone https://github.com/microsoft/vcpkg.git
+$ ./bootstrap-vcpkg.bat # 使用 powershell
+$ ./bootstrap-vcpkg.sh # 使用 bash
+$ ./vcpkg install brpc
+```
+
 ## 自己构建依赖的Linux
 
 ### 依赖准备

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -107,6 +107,18 @@ Examples link brpc statically, if you need to link the shared version, remove `C
 $ mkdir build && cd build && cmake -DBUILD_UNIT_TESTS=ON .. && make && make test
 ```
 
+### Compile brpc with vcpkg
+
+[vcpkg](https://github.com/microsoft/vcpkg) is a package manager that supports all platforms,
+you can use vcpkg to build llvm with the following step:
+
+```shell
+$ git clone https://github.com/microsoft/vcpkg.git
+$ ./bootstrap-vcpkg.bat # for powershell
+$ ./bootstrap-vcpkg.sh # for bash
+$ ./vcpkg install brpc
+```
+
 ## Fedora/CentOS
 
 ### Prepare deps


### PR DESCRIPTION
`brpc` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `brpc` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `brpc`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/brpc/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)

