### PR TITLE
limiting max bytes in stream comsume queue with the same host socket

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -83,6 +83,10 @@ DEFINE_int64(socket_max_unwritten_bytes, 64 * 1024 * 1024,
              "Max unwritten bytes in each socket, if the limit is reached,"
              " Socket.Write fails with EOVERCROWDED");
 
+DEFINE_int64(socket_max_streams_unconsumed_bytes, 0,
+             "Max stream receivers' unconsumed bytes in one socket,"
+             " it used in stream for receiver buffer control.");
+
 DEFINE_int32(max_connection_pool_size, 100,
              "Max number of pooled connections to a single endpoint");
 BRPC_VALIDATE_GFLAG(max_connection_pool_size, PassValidate);
@@ -455,6 +459,7 @@ Socket::Socket(Forbidden)
     , _epollout_butex(NULL)
     , _write_head(NULL)
     , _stream_set(NULL)
+    , _total_streams_buffer_size(0)
     , _ninflight_app_health_check(0)
 {
     CreateVarsOnce();
@@ -640,6 +645,7 @@ int Socket::Create(const SocketOptions& options, SocketId* id) {
     m->_error_code = 0;
     m->_error_text.clear();
     m->_agent_socket_id.store(INVALID_SOCKET_ID, butil::memory_order_relaxed);
+    m->_total_streams_buffer_size.store(0, butil::memory_order_relaxed);
     m->_ninflight_app_health_check.store(0, butil::memory_order_relaxed);
     // NOTE: last two params are useless in bthread > r32787
     const int rc = bthread_id_list_init(&m->_id_wait_list, 512, 512);
@@ -2149,6 +2155,8 @@ void Socket::DebugSocket(std::ostream& os, SocketId id) {
        << "\nlogoff_flag=" << ptr->_logoff_flag.load(butil::memory_order_relaxed)
        << "\n_additional_ref_status="
        << ptr->_additional_ref_status.load(butil::memory_order_relaxed)
+       << "\ntotal_streams_buffer_size="
+       << ptr->_total_streams_buffer_size.load(butil::memory_order_relaxed)
        << "\nninflight_app_health_check="
        << ptr->_ninflight_app_health_check.load(butil::memory_order_relaxed)
        << "\nagent_socket_id=";

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -848,6 +848,7 @@ private:
 
     butil::Mutex _stream_mutex;
     std::set<StreamId> *_stream_set;
+    butil::atomic<int64_t> _total_streams_buffer_size;
 
     butil::atomic<int64_t> _ninflight_app_health_check;
 };

--- a/src/brpc/stream.h
+++ b/src/brpc/stream.h
@@ -49,11 +49,17 @@ public:
 
 struct StreamOptions {
     StreamOptions()
-        : max_buf_size(2 * 1024 * 1024)
+        : min_buf_size(1024 * 1024)
+        , max_buf_size(2 * 1024 * 1024)
         , idle_timeout_ms(-1)
         , messages_in_batch(128)
         , handler(NULL)
     {}
+
+    // The max size of unconsumed data allowed at remote side. 
+    // If |max_buf_size| <= 0, there's no limit of buf size
+    // default: 1048576 (1M)
+    int min_buf_size;
 
     // The max size of unconsumed data allowed at remote side. 
     // If |max_buf_size| <= 0, there's no limit of buf size

--- a/src/brpc/stream_impl.h
+++ b/src/brpc/stream_impl.h
@@ -71,6 +71,7 @@ friend class MessageBatcher;
     ~Stream();
     int Init(const StreamOptions options);
     void SetRemoteConsumed(size_t _remote_consumed);
+    void SetRemoteConsumed(size_t _remote_consumed, int64_t remote_stream_buffer_remain);
     void TriggerOnConnectIfNeed();
     void Wait(void (*on_writable)(StreamId, void*, int), void* arg, 
               const timespec* due_time, bool new_thread, bthread_id_t *join_id);
@@ -114,9 +115,11 @@ friend class MessageBatcher;
     bthread_mutex_t _congestion_control_mutex;
     size_t _produced;
     size_t _remote_consumed;
+    size_t _cur_max_buf_size;
     bthread_id_list_t _writable_wait_list;
 
     int64_t _local_consumed;
+    butil::atomic<int64_t> _on_consumer_queue_size;
     StreamSettings _remote_settings;   
 
     bool _parse_rpc_response;

--- a/src/brpc/streaming_rpc_meta.proto
+++ b/src/brpc/streaming_rpc_meta.proto
@@ -45,4 +45,5 @@ message StreamFrameMeta {
 
 message Feedback {
     optional int64 consumed_size = 1;
+    optional int64 remain_buffer_size = 2;
 }


### PR DESCRIPTION
1. Add **socket_max_streams_unconsumed_bytes** to socket for limiting max bytes in stream comsume queue with the same host socket.  
2. Add **min_buffer_size** to stream options and  **remain_buffer_size** to message Feedback for stream buffer control.