### PR TITLE
Fix the linkage errors caused by duplicate symbols

### DIFF
--- a/src/butil/class_name.h
+++ b/src/butil/class_name.h
@@ -30,7 +30,7 @@ namespace butil {
 
 std::string demangle(const char* name);
 
-namespace detail {
+namespace {
 template <typename T> struct ClassNameHelper { static std::string name; };
 template <typename T> std::string ClassNameHelper<T>::name = demangle(typeid(T).name());
 }
@@ -39,7 +39,7 @@ template <typename T> std::string ClassNameHelper<T>::name = demangle(typeid(T).
 template <typename T> const std::string& class_name_str() {
     // We don't use static-variable-inside-function because before C++11
     // local static variable is not guaranteed to be thread-safe.
-    return detail::ClassNameHelper<T>::name;
+    return ClassNameHelper<T>::name;
 }
 
 // Get name of class |T|, in const char*.


### PR DESCRIPTION
Recently, I met some linkage errors while using `LLD` linker to compile the source code of Apache Doris. The issue looks like #1809 .

**src/butil/class_name.h**
```cpp
namespace detail {
template <typename T> struct ClassNameHelper { static std::string name; };
template <typename T> std::string ClassNameHelper<T>::name = demangle(typeid(T).name());
}
```

The linkage of ```ClassNameHelper<T>::name``` here is external due to it is variable template and it may cause the duplicate symbols error.

Some ways to fix it:
1. In C++ 17, use `inline variable`.
2. Before C++ 17, use unnamed namespace to make the linkage of ```ClassNameHelper<T>::name``` internal.

In this PR, I suggest using the second way to fix it.