### PR TITLE
fix bvar compile error

### DIFF
--- a/src/bvar/mvariable.cpp
+++ b/src/bvar/mvariable.cpp
@@ -45,7 +45,7 @@ static bool validator_bvar_max_multi_dimension_metric_number(const char*, int32_
     return true;
 }
 
-const bool ALLOW_UNUSED dummp_bvar_max_multi_dimension_metric_number = ::google::RegisterFlagValidator(
+const bool ALLOW_UNUSED dummp_bvar_max_multi_dimension_metric_number = ::GFLAGS_NS::RegisterFlagValidator(
     &FLAGS_bvar_max_multi_dimension_metric_number, validator_bvar_max_multi_dimension_metric_number);
 
 class MVarEntry {

--- a/src/bvar/variable.cpp
+++ b/src/bvar/variable.cpp
@@ -920,11 +920,11 @@ const bool ALLOW_UNUSED dummy_bvar_dump_prefix = ::GFLAGS_NS::RegisterFlagValida
 const bool ALLOW_UNUSED dummy_bvar_dump_tabs = ::GFLAGS_NS::RegisterFlagValidator(
     &FLAGS_bvar_dump_tabs, wakeup_dumping_thread);
 
-const bool ALLOW_UNUSED dummy_mbvar_dump = ::google::RegisterFlagValidator(
+const bool ALLOW_UNUSED dummy_mbvar_dump = ::GFLAGS_NS::RegisterFlagValidator(
     &FLAGS_mbvar_dump, validate_bvar_dump);
-const bool ALLOW_UNUSED dummy_mbvar_dump_prefix = ::google::RegisterFlagValidator(
+const bool ALLOW_UNUSED dummy_mbvar_dump_prefix = ::GFLAGS_NS::RegisterFlagValidator(
     &FLAGS_mbvar_dump_prefix, wakeup_dumping_thread);
-const bool ALLOW_UNUSED dump_mbvar_dump_file = ::google::RegisterFlagValidator(
+const bool ALLOW_UNUSED dump_mbvar_dump_file = ::GFLAGS_NS::RegisterFlagValidator(
     &FLAGS_mbvar_dump_file, wakeup_dumping_thread);
 
 static bool validate_mbvar_dump_format(const char*, const std::string& format) {
@@ -940,7 +940,7 @@ static bool validate_mbvar_dump_format(const char*, const std::string& format) {
     return true;
 }
 
-const bool ALLOW_UNUSED dummy_mbvar_dump_format = ::google::RegisterFlagValidator(
+const bool ALLOW_UNUSED dummy_mbvar_dump_format = ::GFLAGS_NS::RegisterFlagValidator(
     &FLAGS_mbvar_dump_format, validate_mbvar_dump_format);
 
 void to_underscored_name(std::string* name, const butil::StringPiece& src) {


### PR DESCRIPTION
I encountered a problem about compiling brpc on Centos7.9 by using config_brpc.sh, for example:
```
src/bvar/variable.cpp:923:46: error: '::google' has not been declared
 const bool ALLOW_UNUSED dummy_mbvar_dump = ::google::RegisterFlagValidator(
                                              ^~~~~~
src/bvar/variable.cpp:925:53: error: '::google' has not been declared
 const bool ALLOW_UNUSED dummy_mbvar_dump_prefix = ::google::RegisterFlagValidator(
                                                     ^~~~~~
src/bvar/variable.cpp:927:50: error: '::google' has not been declared
 const bool ALLOW_UNUSED dump_mbvar_dump_file = ::google::RegisterFlagValidator(
                                                  ^~~~~~
src/bvar/variable.cpp:943:53: error: '::google' has not been declared
 const bool ALLOW_UNUSED dummy_mbvar_dump_format = ::google::RegisterFlagValidator(
```
Fix: Replace `::google::RegisterFlagValidator` with `::GFLAGS_NS::RegisterFlagValidator`.

