### PR TITLE
fix(rpc_replay) continue when failed to init channel

### DIFF
--- a/tools/rpc_replay/rpc_replay.cpp
+++ b/tools/rpc_replay/rpc_replay.cpp
@@ -83,7 +83,9 @@ int ChannelGroup::Init() {
     _chans.resize(max_protocol_size + 1);
     for (size_t i = 0; i < protocols.size(); ++i) {
         if (protocols[i].second.support_client() &&
-            protocols[i].second.support_server()) {
+            protocols[i].second.support_server() &&
+            (brpc::StringToConnectionType(FLAGS_connection_type) &
+             protocols[i].second.supported_connection_type)) {
             const brpc::ProtocolType prot = protocols[i].first;
             brpc::Channel* chan = new brpc::Channel;
             brpc::ChannelOptions options;
@@ -93,8 +95,8 @@ int ChannelGroup::Init() {
             options.max_retry = FLAGS_max_retry;
             if (chan->Init(FLAGS_server.c_str(), FLAGS_load_balancer.c_str(),
                         &options) != 0) {
-                LOG(WARNING) << "Fail to initialize channel";
-                continue;
+                LOG(ERROR) << "Fail to initialize channel";
+                return -1;
             }
             _chans[prot] = chan;
         }

--- a/tools/rpc_replay/rpc_replay.cpp
+++ b/tools/rpc_replay/rpc_replay.cpp
@@ -29,6 +29,9 @@
 #include <brpc/serialized_request.h>
 #include <brpc/nshead_message.h>
 #include <brpc/details/http_message.h>
+#include "brpc/adaptive_connection_type.h"
+#include "brpc/adaptive_protocol_type.h"
+#include "brpc/options.pb.h"
 #include "info_thread.h"
 
 DEFINE_string(dir, "", "The directory of dumped requests");
@@ -83,16 +86,21 @@ int ChannelGroup::Init() {
     _chans.resize(max_protocol_size + 1);
     for (size_t i = 0; i < protocols.size(); ++i) {
         if (protocols[i].second.support_client() &&
-            protocols[i].second.support_server() &&
-            (brpc::StringToConnectionType(FLAGS_connection_type) &
-             protocols[i].second.supported_connection_type)) {
+            protocols[i].second.support_server()) {
             const brpc::ProtocolType prot = protocols[i].first;
-            brpc::Channel* chan = new brpc::Channel;
             brpc::ChannelOptions options;
             options.protocol = prot;
             options.connection_type = FLAGS_connection_type;
             options.timeout_ms = FLAGS_timeout_ms/*milliseconds*/;
             options.max_retry = FLAGS_max_retry;
+            if (options.connection_type != brpc::CONNECTION_TYPE_UNKNOWN &&
+                !(options.connection_type &
+                 protocols[i].second.supported_connection_type)) {
+              // If protoctol does not support user specified connection type,
+              // skip to init channel.
+              continue;
+            }
+            brpc::Channel* chan = new brpc::Channel;
             if (chan->Init(FLAGS_server.c_str(), FLAGS_load_balancer.c_str(),
                         &options) != 0) {
                 LOG(ERROR) << "Fail to initialize channel";

--- a/tools/rpc_replay/rpc_replay.cpp
+++ b/tools/rpc_replay/rpc_replay.cpp
@@ -93,8 +93,8 @@ int ChannelGroup::Init() {
             options.max_retry = FLAGS_max_retry;
             if (chan->Init(FLAGS_server.c_str(), FLAGS_load_balancer.c_str(),
                         &options) != 0) {
-                LOG(ERROR) << "Fail to initialize channel";
-                return -1;
+                LOG(WARNING) << "Fail to initialize channel";
+                continue;
             }
             _chans[prot] = chan;
         }


### PR DESCRIPTION
rpc_replay 在 `ChannelGroup` 初始化时，即使有channel Init 失败（预期行为）应该直接 continue， 而不是返回 -1,  否则会导致程序直接退出，无法继续向下执行。

例如当 `-connection_type=pooled`， rtmp 协议由于不支持 pooled 模式，导致程序退出。本来的 rpc_data 中只有 `baidu_std` 协议，导致无法正常使用。