### PR TITLE
fix typo in getting_started doc

### DIFF
--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -110,7 +110,7 @@ $ mkdir build && cd build && cmake -DBUILD_UNIT_TESTS=ON .. && make && make test
 ### Compile brpc with vcpkg
 
 [vcpkg](https://github.com/microsoft/vcpkg) is a package manager that supports all platforms,
-you can use vcpkg to build llvm with the following step:
+you can use vcpkg to build brpc with the following step:
 
 ```shell
 $ git clone https://github.com/microsoft/vcpkg.git


### PR DESCRIPTION
I'm a contributor for the brpc vcpkg port. I found a typo in the doc.

related PR

https://github.com/apache/incubator-brpc/pull/1925