### PR TITLE
Fix "sched_to itself" error when building by Clang on Linux aarch64

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -248,6 +248,9 @@ int TaskGroup::init(size_t runqueue_capacity) {
     return 0;
 }
 
+#if defined(__linux__) && defined(__aarch64__) && defined(__clang__)
+    __attribute__((optnone))
+#endif
 void TaskGroup::task_runner(intptr_t skip_remained) {
     // NOTE: tls_task_group is volatile since tasks are moved around
     //       different groups.
@@ -567,6 +570,9 @@ void TaskGroup::sched(TaskGroup** pg) {
     sched_to(pg, next_tid);
 }
 
+#if defined(__linux__) && defined(__aarch64__) && defined(__clang__)
+    __attribute__((optnone))
+#endif
 void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
     TaskGroup* g = *pg;
 #ifndef NDEBUG


### PR DESCRIPTION
修复在Linux aarch64平台上用Clang编译器编译，运行时报出来的`sched_to itself`错误。

项目：Apache Doris
平台：Ubuntu 22.04 aarch64
编译器：Ubuntu clang version 14.0.0-1ubuntu1
验证：用clang编译后跑UT，`./run-be-ut.sh` --run