### PR TITLE
fix arena cleared early when parse redis message

### DIFF
--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -190,7 +190,9 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
         wopt.ignore_eovercrowded = true;
         LOG_IF(WARNING, socket->Write(&sendbuf, &wopt) != 0)
             << "Fail to send redis reply";
-        ctx->arena.clear();
+        if(ctx->parser.ParsedArgsSize() == 0) {
+            ctx->arena.clear();
+        }
         return MakeParseError(err);
     } else {
         // NOTE(gejun): PopPipelinedInfo() is actually more contended than what

--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -361,6 +361,10 @@ RedisCommandParser::RedisCommandParser()
     , _length(0)
     , _index(0) {}
 
+size_t RedisCommandParser::ParsedArgsSize() {
+    return _args.size();
+}
+
 ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
                                        std::vector<butil::StringPiece>* args,
                                        butil::Arena* arena) {

--- a/src/brpc/redis_command.h
+++ b/src/brpc/redis_command.h
@@ -53,6 +53,7 @@ public:
     // in `arena'.
     ParseError Consume(butil::IOBuf& buf, std::vector<butil::StringPiece>* args,
                        butil::Arena* arena);
+    size_t ParsedArgsSize();
 
 private:
     // Reset parser to the initial state.


### PR DESCRIPTION
当 RedisCommandParser::Consume 返回 PARSE_ERROR_NOT_ENOUGH_DATA 时，已经 parse 过的数据可能被  ctx->arena.clear() 掉，下次继续parse时，解析过的 _args 内存已经被释放了。
