### PR TITLE
fix: domain name length

### DIFF
--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -304,12 +304,17 @@ int str2endpoint(const char* ip_str, int port, EndPoint* point) {
 
 int hostname2endpoint(const char* str, EndPoint* point) {
     // Should be enough to hold ip address
-    char buf[64];
+    // The definitive descriptions of the rules for forming domain names appear in RFC 1035, RFC 1123, RFC 2181,
+    // and RFC 5892. The full domain name may not exceed the length of 253 characters in its textual representation
+    // (Domain Names - Domain Concepts and Facilities. IETF. doi:10.17487/RFC1034. RFC 1034.).
+    // For cacheline optimize, use buf size as 256;
+    char buf[256];
     size_t i = 0;
-    for (; i < sizeof(buf) - 1 && str[i] != '\0' && str[i] != ':'; ++i) {
+    for (; i < MAX_DOMAIN_LENGTH && str[i] != '\0' && str[i] != ':'; ++i) {
         buf[i] = str[i];
     }
-    if (i == sizeof(buf) - 1) {
+
+    if (i >= MAX_DOMAIN_LENGTH || str[i] != ':') {
         return -1;
     }
 

--- a/src/butil/endpoint.h
+++ b/src/butil/endpoint.h
@@ -34,6 +34,7 @@ typedef struct in_addr ip_t;
 
 static const ip_t IP_ANY = { INADDR_ANY };
 static const ip_t IP_NONE = { INADDR_NONE };
+static const int MAX_DOMAIN_LENGTH = 253;
 
 // Convert |ip| to an integral
 inline in_addr_t ip2int(ip_t ip) { return ip.s_addr; }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #1911 

Problem Summary: hostname2endpoint implement is not compatite with domain RFCs.

### What is changed and the side effects?

Changed: change the buf length as 256, and use MAX_DOMAIN_LENGTH to check the domain name valid. But I don't have an exists domain to test it.

Side effects:
- Performance effects(性能影响): hostname2endpoint will allocate more 192 byte memory in stack.

- Breaking backward compatibility(向后兼容性):  yes

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../CODE_OF_CONDUCT.md).(请遵循贡献者准则).
