### PR TITLE
add warning for rdma invoke when brpc is not compiled with rdma

### DIFF
--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -633,4 +633,19 @@ bool SupportedByRdma(std::string protocol) {
 }  // namespace rdma
 }  // namespace brpc
 
+#else
+
+#include <stdlib.h>
+#include "butil/logging.h"
+
+namespace brpc {
+namespace rdma {
+void GlobalRdmaInitializeOrDie() {
+    LOG(ERROR) << "brpc is not compiled with rdma. To enable it, please refer to "
+               << "https://github.com/apache/incubator-brpc/blob/master/docs/en/rdma.md";
+    exit(1);
+}
+}
+}
+
 #endif  // if BRPC_WITH_RDMA


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #1966

Problem Summary: 

When brpc is not compiled with rdma, a binary may not be linked correctly if the application invoke it.

### What is changed and the side effects?

Changed:
Add warning and force exit in GlobalRdmaInitializeOrDie if BRPC_WITH_RDMA is not defined.

Side effects: 
- Performance effects(性能影响): None

- Breaking backward compatibility(向后兼容性): None

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../CODE_OF_CONDUCT.md).(请遵循贡献者准则).
