### PR TITLE
Fall back to libibverbs.so.1

### DIFF
--- a/docs/cn/rdma.md
+++ b/docs/cn/rdma.md
@@ -24,9 +24,9 @@ make
 使用bazel:
 ```bash
 # Server
-bazel build example:rdma_performance_server
+bazel build --define=BRPC_WITH_RDMA=true example:rdma_performance_server
 # Client
-bazel build example:rdma_performance_client
+bazel build --define=BRPC_WITH_RDMA=true example:rdma_performance_client
 ```
 
 # 基本实现

--- a/docs/en/rdma.md
+++ b/docs/en/rdma.md
@@ -24,9 +24,9 @@ make
 With bazel:
 ```bash
 # Server
-bazel build example:rdma_performance_server
+bazel build --define=BRPC_WITH_RDMA=true example:rdma_performance_server
 # Client
-bazel build example:rdma_performance_client
+bazel build --define=BRPC_WITH_RDMA=true example:rdma_performance_client
 ```
 
 # Basic Implementation

--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -326,8 +326,14 @@ static void OnRdmaAsyncEvent(Socket* m) {
 static int ReadRdmaDynamicLib() {
     g_handle_ibverbs = dlopen("libibverbs.so", RTLD_LAZY);
     if (!g_handle_ibverbs) {
-        LOG(ERROR) << "Fail to load libibverbs.so due to " << dlerror();
-        return -1;
+        LOG(WARNING) << "Failed to load libibverbs.so " << dlerror() << " try libibverbs.so.1";
+        // Clear existing error
+        dlerror();
+        g_handle_ibverbs = dlopen("libibverbs.so.1", RTLD_LAZY);
+        if (!g_handle_ibverbs) {
+            LOG(ERROR) << "Fail to load libibverbs.so.1 due to " << dlerror();
+            return -1;
+        }
     }
 
     LoadSymbol(g_handle_ibverbs, IbvGetDeviceList, "ibv_get_device_list");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).

`libibverbs.so` is provided by `libibverbs-dev` and it is a symbol link to `libibverbs.so.1` which is provided by `libibverbs1`.
We do not need `-dev` package in production environment. So linking to `libibverbs.so.1` is a better solution.

```bash
lrwxrwxrwx 1 root root   15 Jan 28  2022 /usr/lib/x86_64-linux-gnu/libibverbs.so -> libibverbs.so.1
lrwxrwxrwx 1 root root   23 Jan 28  2022 /usr/lib/x86_64-linux-gnu/libibverbs.so.1 -> libibverbs.so.1.14.39.0
-rw-r--r-- 1 root root 139K Jan 28  2022 /usr/lib/x86_64-linux-gnu/libibverbs.so.1.14.39.0
```
Here is `NCCL` usage
https://github.com/NVIDIA/nccl/blob/2f4cb874ba461f67adbd78b6f19fc5bc7c458ab7/src/misc/ibvwrap.cc#L52-L59

Other differs on `rdma.md` is necessary to enable RDMA on `libbrpc`