### PR TITLE
add gflag to disable sampler thread

### DIFF
--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -202,8 +202,14 @@ Sampler::Sampler() : _used(true) {}
 
 Sampler::~Sampler() {}
 
+DEFINE_bool(bvar_enable_sampling, true, "is enable bvar sampling");
+
 void Sampler::schedule() {
-    *butil::get_leaky_singleton<SamplerCollector>() << this;
+    // since the SamplerCollector is initialized before the program starts
+    // flags will not take effect if used in the SamplerCollector constructor
+    if (FLAGS_bvar_enable_sampling) {
+        *butil::get_leaky_singleton<SamplerCollector>() << this;
+    }
 }
 
 void Sampler::destroy() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #1891

Problem Summary: there is currently no gflag to control the switch of the sampler thread

### What is changed and the side effects?

Changed: add `--bvar_enable_sampling` flag to control the switch of the sampler thread. if flag is false, does not create a global singleton SamplerCollector object.

Side effects:
- Performance effects(性能影响):  setting the flag to false will reduce the creation of one thread and the usage of CPU and memory

- Breaking backward compatibility(向后兼容性):  yes

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
