### PR TITLE
Include directly dependent header

### DIFF
--- a/src/brpc/rdma/rdma_helper.h
+++ b/src/brpc/rdma/rdma_helper.h
@@ -21,6 +21,7 @@
 #if BRPC_WITH_RDMA
 
 #include <infiniband/verbs.h>
+#include <string>
 
 
 namespace brpc {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).


`bool SupportedByRdma(std::string protocol);` use `std::string` but forgets to `#include <string>`
See https://github.com/apache/incubator-brpc/blob/7998e68b89164d806933a8deddaa0b8b8f125f1b/src/brpc/rdma/rdma_helper.h#L77

Compile error like this can happen
```bash
external/brpc/src/brpc/rdma/rdma_helper.h:77:27: error: ‘string’ is not a member of ‘std’
   77 | bool SupportedByRdma(std::string protocol);
      |                           ^~~~~~
external/brpc/src/brpc/rdma/rdma_helper.h:24:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
   23 | #include <infiniband/verbs.h>
  +++ |+#include <string>
   24 | 
```