### PR TITLE
allow IOBuf::append_user_data specifying any valid address in registered rdma memory region

### DIFF
--- a/docs/cn/rdma.md
+++ b/docs/cn/rdma.md
@@ -43,6 +43,8 @@ RdmaEndpoint数据传输逻辑的第三个重要特性是事件聚合。每个�
 
 RDMA要求数据收发所使用的内存空间必须被注册（memory register），把对应的页表映射注册给网卡，这一操作非常耗时，所以通常都会使用内存池方案来加速。brpc内部的数据收发都使用IOBuf，为了在兼容IOBuf的情况下实现完全零拷贝，整个IOBuf所使用的内存空间整体由统一内存池接管(参见src/brpc/rdma/block_pool.cpp)。注意，由于IOBuf内存池不由用户直接控制，因此实际使用中需要注意IOBuf所消耗的总内存，建议根据实际业务需求，一次性注册足够的内存池以实现性能最大化。
 
+应用程序可以自己管理内存，然后通过IOBuf::append_user_data把数据发送出去。在这种情况下，应用程序应该自己使用rdma::RegisterMemoryForRdma注册内存（参见src/brpc/rdma/rdma_helper.h）。然而，brpc必须找到这些region对应的正确的memory key，内部使用了一个简单的数组来维护。太多的自定义memory region会影响memory key的查询效率。因此，应用程序应该自己维护一个内存池，并且将内存池一次性注册完毕。
+
 RDMA是硬件相关的通信技术，有很多独特的概念，比如device、port、GID、LID、MaxSge等。这些参数在初始化时会从对应的网卡中读取出来，并且做出默认的选择（参见src/brpc/rdma/rdma_helper.cpp）。有时默认的选择并非用户的期望，则可以通过flag参数方式指定。
 
 # 参数

--- a/docs/en/rdma.md
+++ b/docs/en/rdma.md
@@ -43,6 +43,8 @@ The third key feature in RdmaEndpoint data transmission is event suppression. Th
 
 All the memory used for data transmission in RDMA must be registered, which is very inefficient. Generally, a memory pool is employed to avoid frequent memory registration. In fact, brpc uses IOBuf for data transmission. In order to realize total zerocopy and compatibility with IOBuf, the memory used by IOBuf is taken over by the RDMA memory pool (see src/brpc/rdma/block_pool.cpp). Since IOBuf buffer cannot be controlled by user directly, the total memory consumption in IOBuf should be carefully managed. It is suggested that the application registers enough memory at one time according to its requirement.
 
+The application can manage memory by itself and send data with IOBuf::append_user_data. In this case, the application should register memory by itself with rdma::RegisterMemoryForRdma (see src/brpc/rdma/rdma_helper.h). However, since brpc must find correct memory key for these user-defined memory regions, it uses a simple array to maintain these regions. Too many user-defined regions lead inefficient memory key lookup. Therefore, the application should maintain a memory pool by itself and register the pool one time.
+
 RDMA is hardware-related. It has some different concepts such as device, port, GID, LID, MaxSge and so on. These parameters can be read from NICs at initialization, and brpc will make the default choice (see src/brpc/rdma/rdma_helper.cpp). Sometimes the default choice is not the expectation, then it can be changed in the flag way.
 
 # Parameters

--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -99,15 +99,16 @@ static ibv_device** g_devices = NULL;
 static ibv_context* g_context = NULL;
 static SocketId g_async_socket;
 static ibv_pd* g_pd = NULL;
-static std::vector<ibv_mr*>* g_mrs = NULL;
+static std::vector<ibv_mr*>* g_mrs = NULL; // mr registered by brpc
+
+static const size_t MAX_USER_MRS = 16;
+static ibv_mr* g_user_mrs[MAX_USER_MRS];  // mr registered by user
+static size_t g_user_mrs_cnt = 0;
+static butil::Mutex* g_user_mrs_lock = NULL;
 
 // Store the original IOBuf memalloc and memdealloc functions
 static void* (*g_mem_alloc)(size_t) = NULL;
 static void (*g_mem_dealloc)(void*) = NULL;
-
-butil::Mutex* g_addr_map_lock;
-typedef butil::FlatMap<const void*, ibv_mr*> AddrMap;
-static AddrMap* g_addr_map = NULL;  // for mr not in memory pool
 
 static void GlobalRelease() {
     g_rdma_available.store(false, butil::memory_order_release);
@@ -116,20 +117,23 @@ static void GlobalRelease() {
     // We do not set `g_async_socket' to failed explicitly to avoid
     // close async_fd twice.
 
-    if (g_addr_map_lock) {
-        BAIDU_SCOPED_LOCK(*g_addr_map_lock);
-        if (g_addr_map) {
-            for (AddrMap::iterator it = g_addr_map->begin();
-                    it != g_addr_map->end(); ++it) {
-                IbvDeregMr(it->second);
+    RdmaEndpoint::GlobalRelease();
+
+    if (g_user_mrs_lock) {
+        BAIDU_SCOPED_LOCK(*g_user_mrs_lock);
+        for (size_t i = 0; i < MAX_USER_MRS; ++i) {
+            if (g_user_mrs_cnt == 0) {
+                break;
             }
-            delete g_addr_map;
-            g_addr_map = NULL;  // must set it to NULL
+            if (g_user_mrs[i]) {
+                IbvDeregMr(g_user_mrs[i]);
+                g_user_mrs[i] = NULL;
+                --g_user_mrs_cnt;
+            }
         }
     }
-    delete g_addr_map_lock;
-
-    RdmaEndpoint::GlobalRelease();
+    delete g_user_mrs_lock;
+    g_user_mrs_lock = NULL;
 
     if (g_mrs) {
         for (size_t i = 0; i < g_mrs->size(); ++i) {
@@ -463,6 +467,12 @@ static void GlobalRdmaInitializeOrDieImpl() {
         ExitWithError();
     }
 
+    g_user_mrs_lock = new (std::nothrow) butil::Mutex;
+    if (!g_user_mrs_lock) {
+        PLOG(WARNING) << "Fail to construct g_user_mrs_lock";
+        ExitWithError();
+    }
+
     g_mrs = new (std::nothrow) std::vector<ibv_mr*>;
     if (!g_mrs) {
         PLOG(ERROR) << "Fail to allocate a RDMA MR list";
@@ -491,23 +501,6 @@ static void GlobalRdmaInitializeOrDieImpl() {
     if (RdmaEndpoint::GlobalInitialize() < 0) {
         LOG(ERROR) << "rdma_recv_block_type incorrect "
                    << "(valid value: default/large/huge)";
-        ExitWithError();
-    }
-
-    g_addr_map_lock = new (std::nothrow) butil::Mutex;
-    if (!g_addr_map_lock) {
-        PLOG(WARNING) << "Fail to construct g_addr_map_lock";
-        ExitWithError();
-    }
-
-    g_addr_map = new (std::nothrow) AddrMap;
-    if (!g_addr_map) {
-        PLOG(WARNING) << "Fail to construct g_addr_map";
-        ExitWithError();
-    }
-
-    if (g_addr_map->init(65536) < 0) {
-        PLOG(WARNING) << "Fail to initialize g_addr_map";
         ExitWithError();
     }
 
@@ -544,25 +537,41 @@ void GlobalRdmaInitializeOrDie() {
 }
 
 int RegisterMemoryForRdma(void* buf, size_t len) {
+    BAIDU_SCOPED_LOCK(*g_user_mrs_lock);
+    if (g_user_mrs_cnt == MAX_USER_MRS) {
+        LOG(WARNING) << "brpc supports only " << MAX_USER_MRS << " user-defined MRs. "
+                     << "Too many MRs will affect the efficiency of lkey lookup. "
+                     << "It is suggested to maintain the user-defined buffer with "
+                     << "a memory pool.";
+        return -1;
+    }
     ibv_mr* mr = IbvRegMr(g_pd, buf, len, IBV_ACCESS_LOCAL_WRITE);
     if (!mr) {
         return -1;
     }
-    BAIDU_SCOPED_LOCK(*g_addr_map_lock);
-    if (!g_addr_map->insert(buf, mr)) {
-        IbvDeregMr(mr);
-        return -1;
+    for (size_t i = 0; i < MAX_USER_MRS; ++i) {
+        if (!g_user_mrs[i]) {
+            g_user_mrs[i] = mr;
+            ++g_user_mrs_cnt;
+            break;
+        }
     }
     return 0;
 }
 
 void DeregisterMemoryForRdma(void* buf) {
-    BAIDU_SCOPED_LOCK(*g_addr_map_lock);
-    ibv_mr** mr = g_addr_map->seek(buf);
-    if (mr && *mr) {
-        IbvDeregMr(*mr);
-        g_addr_map->erase(buf);
+    BAIDU_SCOPED_LOCK(*g_user_mrs_lock);
+    for (size_t i = 0; i < MAX_USER_MRS; ++i) {
+        if (g_user_mrs[i]) {
+            if (g_user_mrs[i]->addr == buf) {
+                IbvDeregMr(g_user_mrs[i]);
+                g_user_mrs[i] = NULL;
+                --g_user_mrs_cnt;
+                return;
+            }
+        }
     }
+    LOG(WARNING) << "Try to deregister a buffer which is not registered";
 }
 
 int GetRdmaMaxSge() {
@@ -575,7 +584,7 @@ int GetRdmaCompVector() {
     }
     // g_comp_vector_index is not an atomic variable. If more than
     // one CQ is created at the same time, some CQs will share the
-    // same index. However, this vector is only used to assign a
+    // same index. However, this vector is only used to assign an
     // event queue for the CQ. Sharing the same event queue is not
     // a problem.
     return (g_comp_vector_index++) % g_context->num_comp_vectors;
@@ -591,11 +600,16 @@ ibv_pd* GetRdmaPd() {
 
 uint32_t GetLKey(const void* buf) {
     uint32_t lkey = GetRegionId(buf);
-    if (lkey == 0) {
-        BAIDU_SCOPED_LOCK(*g_addr_map_lock);
-        ibv_mr** mr = g_addr_map->seek(buf);
-        if (mr && *mr) {
-            lkey = (*mr)->lkey;
+    if (lkey == 0 && g_user_mrs_cnt > 0) {
+        for (size_t i = 0; i < MAX_USER_MRS; ++i) {
+            if (!g_user_mrs[i]) {
+                continue;
+            }
+            if ((uintptr_t)g_user_mrs[i]->addr <= (uintptr_t)buf &&
+                (uintptr_t)g_user_mrs[i]->addr + g_user_mrs[i]->length > (uintptr_t)buf) {
+                lkey = g_user_mrs[i]->lkey;
+                break;
+            }
         }
     }
     return lkey;

--- a/src/brpc/rdma/rdma_helper.h
+++ b/src/brpc/rdma/rdma_helper.h
@@ -32,10 +32,14 @@ namespace rdma {
 void GlobalRdmaInitializeOrDie();
 
 // Register the given memory
+// Currently brpc supports only 16 user-defined memory region
+// It is suggested to maintain the buffer with a memory pool
 // Return 0 if success, -1 if failed and errno set
 int RegisterMemoryForRdma(void* buf, size_t len);
 
 // Deregister the given memory
+// All the registered memory will be deregistered automatically
+// when the application exits
 void DeregisterMemoryForRdma(void* buf);
 
 // Get global RDMA context

--- a/test/brpc_rdma_unittest.cpp
+++ b/test/brpc_rdma_unittest.cpp
@@ -80,6 +80,7 @@ extern bool g_skip_rdma_init;
 }
 }
 
+static const size_t MAX_USER_MRS = 16;
 static std::string g_ip = "127.0.0.1";
 static butil::EndPoint g_ep;
 
@@ -959,7 +960,10 @@ TEST_F(RdmaTest, server_hello_invalid_version) {
     usleep(100000);
     ASSERT_EQ(rdma::RdmaEndpoint::FALLBACK_TCP, s->_rdma_ep->_state);
     ASSERT_EQ(4, read(acc_fd, data, 4));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     ASSERT_EQ(0, butil::NetToHost32(*(uint32_t*)data));
+#pragma GCC diagnostic pop
     bthread_id_join(cntl.call_id());
 
     ASSERT_EQ(ERPCTIMEDOUT, cntl.ErrorCode());
@@ -1010,7 +1014,10 @@ TEST_F(RdmaTest, server_hello_invalid_sq_rq_size) {
     usleep(100000);
     ASSERT_EQ(rdma::RdmaEndpoint::FALLBACK_TCP, s->_rdma_ep->_state);
     ASSERT_EQ(4, read(acc_fd, data, 4));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     ASSERT_EQ(0, butil::NetToHost32(*(uint32_t*)data));
+#pragma GCC diagnostic pop
     bthread_id_join(cntl.call_id());
 
     ASSERT_EQ(ERPCTIMEDOUT, cntl.ErrorCode());
@@ -1061,7 +1068,10 @@ TEST_F(RdmaTest, server_miss_after_ack) {
     usleep(100000);
     ASSERT_EQ(rdma::RdmaEndpoint::ESTABLISHED, s->_rdma_ep->_state);
     ASSERT_EQ(4, read(acc_fd, data, 4));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     ASSERT_EQ(1, butil::NetToHost32(*(uint32_t*)data));
+#pragma GCC diagnostic pop
     bthread_id_join(cntl.call_id());
 
     ASSERT_EQ(ERPCTIMEDOUT, cntl.ErrorCode());
@@ -1112,7 +1122,10 @@ TEST_F(RdmaTest, server_close_after_ack) {
     usleep(100000);
     ASSERT_EQ(rdma::RdmaEndpoint::ESTABLISHED, s->_rdma_ep->_state);
     ASSERT_EQ(4, read(acc_fd, data, 4));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     ASSERT_EQ(1, butil::NetToHost32(*(uint32_t*)data));
+#pragma GCC diagnostic pop
     close(acc_fd);
     bthread_id_join(cntl.call_id());
 
@@ -1841,6 +1854,8 @@ TEST_F(RdmaTest, rdma_use_selective_channel) {
     StopServer();
 }
 
+static void MockFree(void* buf) { }
+
 TEST_F(RdmaTest, send_rpcs_with_user_defined_iobuf) {
     if (!FLAGS_rdma_test_enable) {
         return;
@@ -1870,27 +1885,29 @@ TEST_F(RdmaTest, send_rpcs_with_user_defined_iobuf) {
     ASSERT_EQ(ERDMAMEM, cntl[0].ErrorCode());
     attach.clear();
     sleep(2);  // wait for client recover from EHOSTDOWN
+    cntl[0].Reset();
 
-    void* mr[RPC_NUM];
-    butil::IOBuf attachment[RPC_NUM];
-    for (int i = 1; i < RPC_NUM; ++i) {
-        mr[i] = malloc(4096);
+    char* mr[MAX_USER_MRS];
+    for (size_t i = 0; i < MAX_USER_MRS; ++i) {
+        mr[i] = (char*)malloc(4096);
         memset(mr[i], i % 100, 4096);
         ASSERT_EQ(0, rdma::RegisterMemoryForRdma(mr[i], 4096));
-        attachment[i].append_user_data(mr[i], 4096, NULL);
         req[i].set_message(__FUNCTION__);
-        cntl[i].request_attachment().append(attachment[i]);
+        cntl[i].request_attachment().append_user_data(mr[i] + i, 4096 - i, MockFree);
         google::protobuf::Closure* done = DoNothing();
         ::test::EchoService::Stub(&channel).Echo(&cntl[i], &req[i], &res[i], done);
     }
-    for (int i = 1; i < RPC_NUM; ++i) {
+    char tmp;
+    ASSERT_EQ(-1, rdma::RegisterMemoryForRdma(&tmp, 1));
+    for (size_t i = 0; i < MAX_USER_MRS; ++i) {
         bthread_id_join(cntl[i].call_id());
         ASSERT_EQ(0, cntl[i].ErrorCode()) << "req[" << i << "]";
         rdma::DeregisterMemoryForRdma(mr[i]);
-        ASSERT_EQ(4096, cntl[i].response_attachment().size());
+        ASSERT_EQ(4096 - i, cntl[i].response_attachment().size());
         char tmp[4096];
-        cntl[i].response_attachment().copy_to(tmp, 4096);
-        ASSERT_EQ(0, memcmp(mr[i], tmp, 4096));
+        cntl[i].response_attachment().copy_to(tmp, 4096 - i);
+        ASSERT_EQ(0, memcmp(mr[i] + i, tmp, 4096 - i));
+        free(mr[i]);
     }
 
     StopServer();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: [1995](https://github.com/apache/incubator-brpc/issues/1995)

Problem Summary: When using IOBuf::append_user_data, if the application specify a buffer with an offset over the base address registered with rdma::RegisterMemoryForRdma, brpc reports a failure for invalid memory region.

### What is changed and the side effects?

Changed: Use a fixed-length array to manage the user-defined memory regions. To lookup the lkey for a buffer specified in append_user_data, brpc scans the array to find the correct region. To guarantee the performance of lkey lookup, we avoid using mutex for the lookup in this array. 

Side effects:
- Performance effects(性能影响): 

- Breaking backward compatibility(向后兼容性): To guarantee the performance of lkey (linear) lookup, brpc only support at most 16 user-defined memory regions. The application should maintain the user-defined buffer with a memory pool and register the pool one time. And since the lookup is not guarded with a mutex, the application should try not to register or deregister memory during rpc processing.

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
