### PR TITLE
src/butil: correct assign atomic pointer member to be NULL

### DIFF
--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -733,7 +733,9 @@ RtmpContext::RtmpContext(const RtmpClientOptions* copt, const Server* server)
     _free_ms_ids.reserve(32);
     CHECK_EQ(0, _mstream_map.init(1024, 70));
     CHECK_EQ(0, _trans_map.init(1024, 70));
-    memset(static_cast<void*>(_cstream_ctx), 0, sizeof(_cstream_ctx));
+    for (size_t i = 0; i < ARRAY_SIZE(_cstream_ctx); ++i) {
+        _cstream_ctx[i].store(NULL, butil::memory_order_relaxed);
+    }
 }
     
 RtmpContext::~RtmpContext() {
@@ -809,7 +811,9 @@ RtmpUnsentMessage::AppendAndDestroySelf(butil::IOBuf* out, Socket* s) {
 }
 
 RtmpContext::SubChunkArray::SubChunkArray() {
-    memset(static_cast<void*>(ptrs), 0, sizeof(ptrs));
+    for (size_t i = 0; i < ARRAY_SIZE(ptrs); ++i) {
+        ptrs[i].store(NULL, butil::memory_order_relaxed);
+    }
 }
 
 RtmpContext::SubChunkArray::~SubChunkArray() {

--- a/src/bthread/fd.cpp
+++ b/src/bthread/fd.cpp
@@ -49,7 +49,9 @@ class LazyArray {
 
 public:
     LazyArray() {
-        memset(static_cast<void*>(_blocks), 0, sizeof(butil::atomic<Block*>) * NBLOCK);
+        for (size_t i = 0; i < ARRAY_SIZE(_blocks); ++i) {
+            _blocks[i].store(NULL, butil::memory_order_relaxed);
+        }
     }
 
     butil::atomic<T>* get_or_new(size_t index) {

--- a/src/butil/object_pool_inl.h
+++ b/src/butil/object_pool_inl.h
@@ -114,7 +114,9 @@ public:
             // We fetch_add nblock in add_block() before setting the entry,
             // thus address_resource() may sees the unset entry. Initialize
             // all entries to NULL makes such address_resource() return NULL.
-            memset(static_cast<void*>(blocks), 0, sizeof(butil::atomic<Block*>) * OP_GROUP_NBLOCK);
+            for (size_t i = 0; i < ARRAY_SIZE(blocks); ++i) {
+                blocks[i].store(NULL, butil::memory_order_relaxed);
+            }
         }
     };
 

--- a/src/butil/resource_pool_inl.h
+++ b/src/butil/resource_pool_inl.h
@@ -130,7 +130,9 @@ public:
             // We fetch_add nblock in add_block() before setting the entry,
             // thus address_resource() may sees the unset entry. Initialize
             // all entries to NULL makes such address_resource() return NULL.
-            memset(static_cast<void*>(blocks), 0, sizeof(butil::atomic<Block*>) * RP_GROUP_NBLOCK);
+            for (size_t i = 0; i < ARRAY_SIZE(blocks); ++i) {
+                blocks[i].store(NULL, butil::memory_order_relaxed);
+            }
         }
     };
 


### PR DESCRIPTION
1. memset assign value to var without considering var type.
2. memset can't guarantee atomic operation

Signed-off-by: Liu, Changcheng <changcheng.liu@aliyun.com>
