### PR TITLE
Early return when size == 0

### DIFF
--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1211,18 +1211,16 @@ int IOBuf::append_user_data(void* data, size_t size, void (*deleter)(void*)) {
         LOG(FATAL) << "data_size=" << size << " is too large";
         return -1;
     }
+    if (!deleter) {
+        deleter = ::free;
+    }
     if (!size) {
-        if (deleter) {
-            deleter(data);
-        }
+        deleter(data);
         return 0;
     }
     char* mem = (char*)malloc(sizeof(IOBuf::Block) + sizeof(UserDataExtension));
     if (mem == NULL) {
         return -1;
-    }
-    if (deleter == NULL) {
-        deleter = ::free;
     }
     IOBuf::Block* b = new (mem) IOBuf::Block((char*)data, size, deleter);
     const IOBuf::BlockRef r = { 0, b->cap, b };

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1212,6 +1212,9 @@ int IOBuf::append_user_data(void* data, size_t size, void (*deleter)(void*)) {
         return -1;
     }
     if (!size) {
+        if (deleter) {
+            deleter(data);
+        }
         return 0;
     }
     char* mem = (char*)malloc(sizeof(IOBuf::Block) + sizeof(UserDataExtension));

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1211,6 +1211,9 @@ int IOBuf::append_user_data(void* data, size_t size, void (*deleter)(void*)) {
         LOG(FATAL) << "data_size=" << size << " is too large";
         return -1;
     }
+    if (!size) {
+        return 0;
+    }
     char* mem = (char*)malloc(sizeof(IOBuf::Block) + sizeof(UserDataExtension));
     if (mem == NULL) {
         return -1;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).

As pointed out by @Tuvie https://github.com/apache/incubator-brpc/issues/1995#issuecomment-1323723025, when `IOBuf::append_user_data` is called with size 0, we can do early return. This avoids unnecessary block memory allocation in the later.