### PR TITLE
ssl错误码问题

### DIFF
--- a/src/brpc/details/ssl_helper.cpp
+++ b/src/brpc/details/ssl_helper.cpp
@@ -350,7 +350,7 @@ static int LoadCertificate(SSL_CTX* ctx,
     if (err != 0 && (ERR_GET_LIB(err) != ERR_LIB_PEM
                      || ERR_GET_REASON(err) != PEM_R_NO_START_LINE)) {
         LOG(ERROR) << "Fail to read chain certificate in "
-                   << certificate << ": " << SSLError(ERR_get_error());
+                   << certificate << ": " << SSLError(err);
         return -1;
     }
     ERR_clear_error();

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1836,7 +1836,7 @@ ssize_t Socket::DoWrite(WriteRequest* req) {
         const unsigned long e = ERR_get_error();
         if (e != 0) {
             LOG(WARNING) << "Fail to write into ssl_fd=" << fd() <<  ": "
-                         << SSLError(ERR_get_error());
+                         << SSLError(e);
             errno = ESSL;
          } else {
             // System error with corresponding errno set
@@ -1879,6 +1879,7 @@ int Socket::SSLHandshake(int fd, bool server_mode) {
     // we use bthread_fd_wait as polling mechanism instead of EventDispatcher
     // as it may confuse the origin event processing code.
     while (true) {
+        ERR_clear_error();
         int rc = SSL_do_handshake(_ssl_session);
         if (rc == 1) {
             _ssl_state = SSL_CONNECTED;

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -19,6 +19,7 @@
 
 // Date: Thu Nov 22 13:57:56 CST 2012
 
+#include <openssl/err.h>
 #include <openssl/ssl.h>                   // SSL_*
 #ifdef USE_MESALINK
 #include <mesalink/openssl/ssl.h>
@@ -977,6 +978,7 @@ ssize_t IOBuf::cut_into_SSL_channel(SSL* ssl, int* ssl_error) {
     }
     
     IOBuf::BlockRef const& r = _ref_at(0);
+    ERR_clear_error();
     const int nw = SSL_write(ssl, r.block->data + r.offset, r.length);
     if (nw > 0) {
         pop_front(nw);
@@ -1679,6 +1681,7 @@ ssize_t IOPortal::append_from_SSL_channel(
         }
 
         const size_t read_len = std::min(_block->left_space(), max_count - nr);
+        ERR_clear_error();
         const int rc = SSL_read(ssl, _block->data + _block->size, read_len);
         *ssl_error = SSL_get_error(ssl, rc);
         if (rc > 0) {


### PR DESCRIPTION
> ERR_get_error() returns the earliest error code from the thread's error queue and removes the entry. This function can be called repeatedly until there are no more error codes to return.

据文档描述，ERR_get_error是会修改线程的错误码队列的，所以多次调用该函数，返回的值并不是同一个。
#1096 可能和这个问题有关。我司线上也有大量的“Fail to write into ssl_fd=, Success”的日志。这个Success可能是第二次调用ERR_get_error的返回值。

> SSL_get_error() returns a result code (suitable for the C "switch" statement) for a preceding call to SSL_connect(), SSL_accept(), SSL_do_handshake(), SSL_read_ex(), SSL_read(), SSL_peek_ex(), SSL_peek(), SSL_shutdown(), SSL_write_ex() or SSL_write() on ssl.

> In addition to ssl and ret, SSL_get_error() inspects the current thread's OpenSSL error queue. Thus, SSL_get_error() must be used in the same thread that performed the TLS/SSL I/O operation, and no other OpenSSL function calls should appear in between. The current thread's error queue must be empty before the TLS/SSL I/O operation is attempted, or SSL_get_error() will not work reliably.

在调用SSL_do_handshake、SSL_read、SSL_write之前最好是先调用ERR_clear_error，这样才能保证这些函数之后调用的SSL_get_error的返回值正确。