### PR TITLE
Make GenericDocument's handler public to enable ouside parser/writer

### DIFF
--- a/src/butil/third_party/rapidjson/document.h
+++ b/src/butil/third_party/rapidjson/document.h
@@ -1942,6 +1942,8 @@ private:
     template <typename,typename,typename> friend class GenericReader; // for parsing
     template <typename, typename> friend class GenericValue; // for deep copying
 
+// NOTE(jrj): Make the following methods public to enable outside parser/writer 
+public:
     // Implementation of Handler
     bool Null() { new (stack_.template Push<ValueType>()) ValueType(); return true; }
     bool Bool(bool b) { new (stack_.template Push<ValueType>()) ValueType(b); return true; }
@@ -1976,6 +1978,17 @@ private:
         stack_.template Top<ValueType>()->SetArrayRaw(elements, elementCount, GetAllocator());
         return true;
     }
+
+    // NOTE(jrj): Extract the last element from the stack and move into `this' GenericDocument
+    void FinalizeHandler() {
+        if (StackSize() > 0) {
+            ValueType* rhs = stack_.template Pop<ValueType>(1);
+            this->RawAssign(*rhs);  // Transfer ownership
+        }
+        RAPIDJSON_ASSERT(stack_.Empty());
+    }
+
+    size_t StackSize() const { return stack_.GetSize(); }
 
 private:
     //! Prohibit copying


### PR DESCRIPTION
Make BUTIL_RAPIDJSON_NAMESPACE_BEGIN::GenericDocument's handler method public to enable outside custom parser/writer
### What problem does this PR solve?

Issue Number: None

Problem Summary: None

### What is changed and the side effects?

Changed: Handler methods of `GenericDocument` changed to public, to enable user customized parser/writer to iterator over the document

Side effects:
- Performance effects(性能影响): None

- Breaking backward compatibility(向后兼容性): None

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
