### PR TITLE
fix bug: QP cannot be put back to QP pool

### DIFF
--- a/src/brpc/rdma/rdma_endpoint.cpp
+++ b/src/brpc/rdma/rdma_endpoint.cpp
@@ -1211,7 +1211,8 @@ void RdmaEndpoint::DeallocateResources() {
     }
     bool move_to_rdma_resource_list = false;
     if (_sq_size <= FLAGS_rdma_prepared_qp_size &&
-        _rq_size <= FLAGS_rdma_prepared_qp_size) {
+        _rq_size <= FLAGS_rdma_prepared_qp_size &&
+        FLAGS_rdma_prepared_qp_cnt > 0) {
         ibv_qp_attr attr;
         attr.qp_state = IBV_QPS_RESET;
         if (IbvModifyQp(_resource->qp, &attr, IBV_QP_STATE) == 0) {
@@ -1241,6 +1242,7 @@ void RdmaEndpoint::DeallocateResources() {
             }
         }
         delete _resource;
+        _resource = NULL;
     }
 
     SocketUniquePtr s;
@@ -1256,7 +1258,7 @@ void RdmaEndpoint::DeallocateResources() {
         _cq_sid = INVALID_SOCKET_ID;
     }
 
-    if (!move_to_rdma_resource_list) {
+    if (move_to_rdma_resource_list) {
         if (_resource->cq) {
             IbvAckCqEvents(_resource->cq, _cq_events);
         }

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1217,10 +1217,6 @@ int IOBuf::append_user_data_with_meta(void* data,
                                       size_t size,
                                       void (*deleter)(void*),
                                       uint64_t meta) {
-    if (size == 0) {
-        LOG(WARNING) << "data_size should not be 0";
-        return -1;
-    }
     if (size > 0xFFFFFFFFULL - 100) {
         LOG(FATAL) << "data_size=" << size << " is too large";
         return -1;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary: fix a QP leak bug

### What is changed and the side effects?

Changed: Modify the condition to move QP back to QP pool when connection destroyed. The QP pool is used as a cache for the QPs in order to reduce the overhead to create a QP during the connection establishment.

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
