### PR TITLE
only allow to convert root array to single repeated pb

### DIFF
--- a/src/json2pb/json_to_pb.cpp
+++ b/src/json2pb/json_to_pb.cpp
@@ -275,7 +275,9 @@ inline bool convert_uint64_type(const BUTIL_RAPIDJSON_NAMESPACE::Value& item,
 
 bool JsonValueToProtoMessage(const BUTIL_RAPIDJSON_NAMESPACE::Value& json_value,
                              google::protobuf::Message* message,
-                             const Json2PbOptions& options, std::string* err);
+                             const Json2PbOptions& options,
+                             std::string* err,
+                             bool root_val = false);
 
 //Json value to protobuf convert rules for type:
 //Json value type                 Protobuf type                convert rules
@@ -516,9 +518,11 @@ bool JsonMapToProtoMap(const BUTIL_RAPIDJSON_NAMESPACE::Value& value,
 bool JsonValueToProtoMessage(const BUTIL_RAPIDJSON_NAMESPACE::Value& json_value,
                              google::protobuf::Message* message,
                              const Json2PbOptions& options,
-                             std::string* err) {
+                             std::string* err,
+                             bool root_val) {
     const google::protobuf::Descriptor* descriptor = message->GetDescriptor();
-    if (!json_value.IsObject() && !(json_value.IsArray() && options.array_to_single_repeated)) {
+    if (!json_value.IsObject() &&
+        !(json_value.IsArray() && options.array_to_single_repeated && root_val)) {
         J2PERROR_WITH_PB(message, err, "The input is not a json object");
         return false;
     }
@@ -627,7 +631,7 @@ inline bool JsonToProtoMessageInline(const std::string& json_string,
         J2PERROR_WITH_PB(message, error, "Invalid json: %s", BUTIL_RAPIDJSON_NAMESPACE::GetParseError_En(d.GetParseError()));
         return false;
     }
-    return JsonValueToProtoMessage(d, message, options, error);
+    return JsonValueToProtoMessage(d, message, options, error, true);
 }
 
 bool JsonToProtoMessage(const std::string& json_string,
@@ -675,7 +679,7 @@ bool JsonToProtoMessage(ZeroCopyStreamReader* reader,
         J2PERROR_WITH_PB(message, error, "Invalid json: %s", BUTIL_RAPIDJSON_NAMESPACE::GetParseError_En(d.GetParseError()));
         return false;
     }
-    return JsonValueToProtoMessage(d, message, options, error);
+    return JsonValueToProtoMessage(d, message, options, error, true);
 }
 
 bool JsonToProtoMessage(const std::string& json_string, 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
目前打开single_repeated_to_array开关后，pb转json只支持root case，但是打开array_to_single_repeated开关，json转pb没有限制root case。这样会导致json转pb，pb再转回json，前后的json结构发生了变化，不符合预期。例如：

```
# pb
meesage Single {
    repeated int ids;
}

message Test {
    Single single;
}

# 打开array_to_single_repeated开关后，以下json可以转为Test
{
    "single": [1,2,3]
}

# 但是打开single_repeated_to_array开关后，Test转为json的格式为：
{
    single: {
        "ids": [1,2,3]
    }
}
```

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性):  如果旧代码希望array_to_single_repeated将非root array转成single  @repedted的话，使用此PR代码后，会导致json转pb失败。

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
