### PR TITLE
fix bug: QP cannot be put back to QP pool

### DIFF
--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1217,10 +1217,6 @@ int IOBuf::append_user_data_with_meta(void* data,
                                       size_t size,
                                       void (*deleter)(void*),
                                       uint64_t meta) {
-    if (size == 0) {
-        LOG(WARNING) << "data_size should not be 0";
-        return -1;
-    }
     if (size > 0xFFFFFFFFULL - 100) {
         LOG(FATAL) << "data_size=" << size << " is too large";
         return -1;


### PR DESCRIPTION
What problem does this PR solve?
Issue Number:

Problem Summary: fix a QP leak bug

What is changed and the side effects?
Changed: Modify the condition to move QP back to QP pool when connection destroyed. The QP pool is used as a cache for the QPs in order to reduce the overhead to create a QP during the connection establishment.

Side effects:

Performance effects(性能影响):

Breaking backward compatibility(向后兼容性):

Check List:
Please make sure your changes are compilable(请确保你的更改可以通过编译).
When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).