### PR TITLE
delete deprecated logoff_ms gflag in example folder

### DIFF
--- a/example/asynchronous_echo_c++/server.cpp
+++ b/example/asynchronous_echo_c++/server.cpp
@@ -26,8 +26,6 @@ DEFINE_bool(send_attachment, true, "Carry attachment along with response");
 DEFINE_int32(port, 8003, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 
 // Your implementation of example::EchoService
 class EchoServiceImpl : public example::EchoService {

--- a/example/auto_concurrency_limiter/server.cpp
+++ b/example/auto_concurrency_limiter/server.cpp
@@ -31,8 +31,6 @@
 #include <fstream>
 #include "cl_test.pb.h"
 
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(server_bthread_concurrency, 4, 
              "Configuring the value of bthread_concurrency, For compute max qps, ");
 DEFINE_int32(server_sync_sleep_us, 2500, 

--- a/example/backup_request_c++/server.cpp
+++ b/example/backup_request_c++/server.cpp
@@ -26,8 +26,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8000, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(sleep_ms, 20, "Sleep so many milliseconds on even-th requests");
 
 // Your implementation of example::EchoService

--- a/example/cancel_c++/server.cpp
+++ b/example/cancel_c++/server.cpp
@@ -26,8 +26,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8000, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 
 // Your implementation of example::EchoService
 // Notice that implementing brpc::Describable grants the ability to put

--- a/example/dynamic_partition_echo_c++/server.cpp
+++ b/example/dynamic_partition_echo_c++/server.cpp
@@ -31,8 +31,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8004, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 DEFINE_int32(server_num, 1, "Number of servers");
 DEFINE_string(sleep_us, "", "Sleep so many microseconds before responding");
@@ -162,11 +160,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Don't forget to stop and join the server otherwise still-running
-    // worker threads may crash your program. Clients will have/ at most
-    // `FLAGS_logoff_ms' to close their connections. If some connections
-    // still remains after `FLAGS_logoff_ms', they will be closed by force.
+    // worker threads may crash your program. 
     for (int i = 0; i < FLAGS_server_num; ++i) {
-        servers[i].Stop(FLAGS_logoff_ms);
+        servers[i].Stop(0/*not used now*/);
     }
     for (int i = 0; i < FLAGS_server_num; ++i) {
         servers[i].Join();

--- a/example/echo_c++/server.cpp
+++ b/example/echo_c++/server.cpp
@@ -28,8 +28,6 @@ DEFINE_string(listen_addr, "", "Server listen address, may be IPV4/IPV6/UDS."
             " If this is set, the flag port will be ignored");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 
 // Your implementation of example::EchoService
 // Notice that implementing brpc::Describable grants the ability to put

--- a/example/grpc_c++/server.cpp
+++ b/example/grpc_c++/server.cpp
@@ -26,8 +26,6 @@
 DEFINE_int32(port, 50051, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_bool(gzip, false, "compress body using gzip");
 
 class GreeterImpl : public helloworld::Greeter {

--- a/example/http_c++/http_server.cpp
+++ b/example/http_c++/http_server.cpp
@@ -26,8 +26,6 @@
 DEFINE_int32(port, 8010, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 
 DEFINE_string(certificate, "cert.pem", "Certificate file path to enable SSL");
 DEFINE_string(private_key, "key.pem", "Private key file path to enable SSL");

--- a/example/multi_threaded_echo_c++/server.cpp
+++ b/example/multi_threaded_echo_c++/server.cpp
@@ -26,8 +26,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8002, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 DEFINE_int32(internal_port, -1, "Only allow builtin services at this port");
 

--- a/example/multi_threaded_echo_fns_c++/server.cpp
+++ b/example/multi_threaded_echo_fns_c++/server.cpp
@@ -32,8 +32,6 @@ DEFINE_bool(send_attachment, false, "Carry attachment along with response");
 DEFINE_int32(port, 8004, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 DEFINE_int32(server_num, 1, "Number of servers");
 DEFINE_string(sleep_us, "", "Sleep so many microseconds before responding");
@@ -177,11 +175,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Don't forget to stop and join the server otherwise still-running
-    // worker threads may crash your program. Clients will have/ at most
-    // `FLAGS_logoff_ms' to close their connections. If some connections
-    // still remains after `FLAGS_logoff_ms', they will be closed by force.
+    // worker threads may crash your program. 
     for (int i = 0; i < FLAGS_server_num; ++i) {
-        servers[i].Stop(FLAGS_logoff_ms);
+        servers[i].Stop(0/*not used now*/);
     }
     for (int i = 0; i < FLAGS_server_num; ++i) {
         servers[i].Join();

--- a/example/parallel_echo_c++/server.cpp
+++ b/example/parallel_echo_c++/server.cpp
@@ -27,8 +27,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8002, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 
 // Your implementation of example::EchoService

--- a/example/partition_echo_c++/server.cpp
+++ b/example/partition_echo_c++/server.cpp
@@ -31,8 +31,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8002, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 DEFINE_int32(server_num, 1, "Number of servers");
 DEFINE_string(sleep_us, "", "Sleep so many microseconds before responding");
@@ -162,11 +160,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Don't forget to stop and join the server otherwise still-running
-    // worker threads may crash your program. Clients will have/ at most
-    // `FLAGS_logoff_ms' to close their connections. If some connections
-    // still remains after `FLAGS_logoff_ms', they will be closed by force.
+    // worker threads may crash your program.
     for (int i = 0; i < FLAGS_server_num; ++i) {
-        servers[i].Stop(FLAGS_logoff_ms);
+        servers[i].Stop(0/*not used now*/);
     }
     for (int i = 0; i < FLAGS_server_num; ++i) {
         servers[i].Join();

--- a/example/selective_echo_c++/server.cpp
+++ b/example/selective_echo_c++/server.cpp
@@ -30,8 +30,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8114, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 DEFINE_int32(server_num, 7, "Number of servers");
 DEFINE_string(sleep_us, "", "Sleep so many microseconds before responding");
@@ -161,11 +159,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Don't forget to stop and join the server otherwise still-running
-    // worker threads may crash your program. Clients will have/ at most
-    // `FLAGS_logoff_ms' to close their connections. If some connections
-    // still remains after `FLAGS_logoff_ms', they will be closed by force.
+    // worker threads may crash your program. 
     for (int i = 0; i < FLAGS_server_num; ++i) {
-        servers[i].Stop(FLAGS_logoff_ms);
+        servers[i].Stop(0/*not used now*/);
     }
     for (int i = 0; i < FLAGS_server_num; ++i) {
         servers[i].Join();

--- a/example/session_data_and_thread_local/server.cpp
+++ b/example/session_data_and_thread_local/server.cpp
@@ -26,8 +26,6 @@ DEFINE_bool(echo_attachment, true, "Echo attachment as well");
 DEFINE_int32(port, 8002, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 DEFINE_int32(max_concurrency, 0, "Limit of request processing in parallel");
 
 butil::atomic<int> nsd(0);

--- a/example/streaming_echo_c++/server.cpp
+++ b/example/streaming_echo_c++/server.cpp
@@ -27,8 +27,6 @@ DEFINE_bool(send_attachment, true, "Carry attachment along with response");
 DEFINE_int32(port, 8001, "TCP Port of this server");
 DEFINE_int32(idle_timeout_s, -1, "Connection will be closed if there is no "
              "read/write operations during the last `idle_timeout_s'");
-DEFINE_int32(logoff_ms, 2000, "Maximum duration of server's LOGOFF state "
-             "(waiting for client to close connection before server stops)");
 
 class StreamReceiver : public brpc::StreamInputHandler {
 public:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2060

Problem Summary: logoff_ms gflag in example is not used.

### What is changed and the side effects?

Changed: delete deprecated logoff_ms gflag in example folder.

Side effects:
- Performance effects(性能影响): no

- Breaking backward compatibility(向后兼容性): yes

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
